### PR TITLE
fix: add support for SSD storages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-            ref: master
 
       - name: Setup Python ${{ env.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-            ref: master
 
       - name: Setup Python ${{ env.python-version }}
         uses: actions/setup-python@v2

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -63,7 +63,7 @@ The following parameters are supported:
 | auto\_increment | no | boolean | true | Whether or not to increment created servers. |
 | count | no | integer | 1 | The number of servers to create. |
 | name | **yes**/no | string |  | The name of the server\(s\). Required only for `state='present'`. |
-| image | **yes**/no | string |  | Image, snapshot ID or image alias to be used as template for the volume of the server. If image alias is used, provide the location and the disk\_type too, in order to identify the correct image ID.  Required only for `state='present'`. |
+| image | **yes**/no | string |  | Image, snapshot ID or image alias to be used as template for the volume of the server. |
 | image\_password | no | string |  | Password set for the administrative user. |
 | ssh\_keys | no | list | none | List of public SSH keys allowing access to the server. |
 | datacenter | **yes** | string | none | The datacenter where the server is located. |
@@ -72,7 +72,7 @@ The following parameters are supported:
 | cpu\_family | no | string | AMD\_OPTERON | The CPU family type of the server: **AMD\_OPTERON**, INTEL\_XEON, INTEL\_SKYLAKE |
 | availability\_zone | no | string | AUTO | The availability zone assigned to the server: **AUTO**, ZONE\_1, ZONE\_2 |
 | volume\_size | no | integer | 10 | The size in GB of the boot volume. |
-| disk\_type | no | string | HDD | The type of disk the volume will use: **HDD**, SSD |
+| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD, SSD Standard or SSD Premium. If `SSD` is provided, it will automatically use `SSD Premium` |
 | volume\_availability\_zone | no | string | AUTO | The storage availability zone assigned to the volume: **AUTO**, ZONE\_1, ZONE\_2, ZONE\_3 |
 | bus | no | string | VIRTIO | The bus type for the volume: **VIRTIO**, IDE |
 | instance\_ids | **yes**/no | list |  | List of instance IDs or names. **Not required** for `state='present'`. |

--- a/docs/api/compute-engine/volume.md
+++ b/docs/api/compute-engine/volume.md
@@ -59,13 +59,12 @@ The following parameters are supported:
 | name | **yes**/no | string |  | The name of the volume. You can enumerate the names using auto\_increment. |
 | size | no | integer | 10 | The size of the volume in GB. |
 | bus | no | string | VIRTIO | The bus type of the volume: **VIRTIO**, IDE |
-| image | no | string |  | Image, snapshot ID or image alias to be used as template for this volume. If image alias is used, provide the location and the disk\_type too, in order to identify the correct image ID. |
-| location | no | string |  | The location of the provided image. This parameter is required only when the image alias is used instead of an UUID for the image. The available locations are: us/las, us/ewr, de/fra, de/fkb, de/txl, gb/lhr |
+| image | no | string |  | Image, snapshot ID or image alias to be used as template for this volume. |
 | backupunit\_id | no | string |  | The uuid of the Backup Unit that user has access to. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property.. |
 | user\_data | no | string |  | The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' that has cloud-init compatibility in conjunction with this property. |
 | image\_password | no | string |  | Password set for the administrative user. |
 | ssh\_keys | no | list |  | Public SSH keys allowing access to the server. |
-| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD |
+| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD, SSD Standard or SSD Premium. If `SSD` is provided, it will automatically use `SSD Premium` |
 | licence\_type | no | string |  | The licence type for the volume. This is used when the image is non-standard: LINUX, WINDOWS, **UNKNOWN**, OTHER, WINDOWS2016 |
 | availability\_zone | no | string | AUTO | The storage availability zone assigned to the volume: **AUTO**, ZONE\_1, ZONE\_2, ZONE\_3 |
 | count | no | integer | 1 | The number of volumes to create. |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -123,3 +123,13 @@
 ### Misc:
 
 * docs: updates the name of the module in examples
+
+## 5.0.9
+
+### Bug fixes:
+
+* fix create volume bug that forced disk_type to be always `HDD` 
+
+### Enhancements:
+
+* add support for SSD storage _(new options for volume storage type: SSD Standard, SSD Premium)_ - **SSD Premium is the default** if disk_type=SSD

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ namespace: ionoscloudsdk
 name: ionoscloud
 
 # The version of the collection.
-version: 5.0.8
+version: 5.0.9
 
 readme: README.md
 

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -377,10 +377,11 @@ def _create_machine(module, client, datacenter, name):
                                          ssh_keys=ssh_keys,
                                          bus=bus)
 
-    if uuid_match.match(image):
-        volume_properties.image = image
-    else:
-        volume_properties.image_alias = image
+    if image:
+        if uuid_match.match(image):
+            volume_properties.image = image
+        else:
+            volume_properties.image_alias = image
 
     volume = Volume(properties=volume_properties)
 

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -267,7 +267,9 @@ CPU_FAMILIES = ['AMD_OPTERON',
                 'INTEL_SKYLAKE']
 
 DISK_TYPES = ['HDD',
-              'SSD']
+              'SSD',
+              'SSD Premium',
+              'SSD Standard']
 
 BUS_TYPES = ['VIRTIO',
              'IDE']
@@ -279,18 +281,6 @@ AVAILABILITY_ZONES = ['AUTO',
 
 uuid_match = re.compile(
     '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
-
-
-def _resolve_image(image_alias, location, disk_type, client):
-    image_client = ionoscloud.api.ImageApi(api_client=client)
-    images = image_client.images_get(depth=5)
-
-    if len(images.items) > 0:
-        for image in images.items:
-            if image_alias in image.properties.image_aliases and location == image.properties.location and disk_type == image.properties.image_type:
-                return image.id
-
-    return None
 
 
 def _get_request_id(headers):
@@ -325,7 +315,6 @@ def _create_machine(module, client, datacenter, name):
     cores = module.params.get('cores')
     ram = module.params.get('ram')
     cpu_family = module.params.get('cpu_family')
-    location = module.params.get('location')
     volume_size = module.params.get('volume_size')
     disk_type = module.params.get('disk_type')
     availability_zone = module.params.get('availability_zone')
@@ -380,23 +369,18 @@ def _create_machine(module, client, datacenter, name):
                 nic.properties.ips = nic_ips
             nics.append(nic)
 
-    if uuid_match.match(image):
-        image_id = image
-    else:
-        image_id = _resolve_image(image, location, disk_type, client)
-
-    if not image_id:
-        module.fail_json(msg="Could not find the image. Please provide either image_id, either image_alias and "
-                             "disk_type parameters")
-
     volume_properties = VolumeProperties(name=str(uuid4()).replace('-', '')[:10],
                                          type=disk_type,
                                          size=volume_size,
-                                         image=image_id,
                                          availability_zone=volume_availability_zone,
                                          image_password=image_password,
                                          ssh_keys=ssh_keys,
                                          bus=bus)
+
+    if uuid_match.match(image):
+        volume_properties.image = image
+    else:
+        volume_properties.image_alias = image
 
     volume = Volume(properties=volume_properties)
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -233,12 +233,12 @@ def _create_volume(module, volume_server, datacenter, name, client):
     user_data = module.params.get('user_data')
     wait_timeout = module.params.get('wait_timeout')
     wait = module.params.get('wait')
-    image_id = None
 
     if module.check_mode:
         module.exit_json(changed=True)
 
     try:
+
         volume_properties = VolumeProperties(name=name, type=disk_type, size=size, availability_zone=availability_zone,
                                              image_password=image_password, ssh_keys=ssh_keys,
                                              bus=bus,
@@ -248,10 +248,11 @@ def _create_volume(module, volume_server, datacenter, name, client):
                                              disc_virtio_hot_unplug=disc_virtio_hot_unplug, backupunit_id=backupunit_id,
                                              user_data=user_data)
 
-        if uuid_match.match(image):
-            volume_properties.image = image
-        else:
-            volume_properties.image_alias = image
+        if image:
+            if uuid_match.match(image):
+                volume_properties.image = image
+            else:
+                volume_properties.image_alias = image
 
         volume = Volume(properties=volume_properties)
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -280,7 +280,6 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
     nic_hot_unplug = module.params.get('nic_hot_unplug')
     disc_virtio_hot_plug = module.params.get('disc_virtio_hot_plug')
     disc_virtio_hot_unplug = module.params.get('disc_virtio_hot_unplug')
-    image_id = None
 
     wait_timeout = module.params.get('wait_timeout')
     wait = module.params.get('wait')
@@ -290,7 +289,7 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
 
     try:
         volume_properties = VolumeProperties(name=name, size=size, availability_zone=availability_zone,
-                                             image=image_id, bus=bus,
+                                             bus=bus,
                                              cpu_hot_plug=cpu_hot_plug, ram_hot_plug=ram_hot_plug,
                                              nic_hot_plug=nic_hot_plug, nic_hot_unplug=nic_hot_unplug,
                                              disc_virtio_hot_plug=disc_virtio_hot_plug,

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -182,7 +182,9 @@ from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_native
 
 DISK_TYPES = ['HDD',
-              'SSD']
+              'SSD',
+              'SSD Premium',
+              'SSD Standard']
 
 BUS_TYPES = ['VIRTIO',
              'IDE']
@@ -211,22 +213,10 @@ def _get_request_id(headers):
                         "header 'location': '{location}'".format(location=headers['location']))
 
 
-def _resolve_image(image_alias, location, disk_type, client):
-    image_client = ionoscloud.api.ImageApi(api_client=client)
-    images = image_client.images_get(depth=5)
-
-    if len(images.items) > 0:
-        for image in images.items:
-            if image_alias in image.properties.image_aliases and location == image.properties.location and disk_type == image.properties.image_type:
-                return image.id
-
-    return None
-
 
 def _create_volume(module, volume_server, datacenter, name, client):
     size = module.params.get('size')
     bus = module.params.get('bus')
-    location = module.params.get('location')
     image = module.params.get('image')
     image_password = module.params.get('image_password')
     ssh_keys = module.params.get('ssh_keys')
@@ -248,25 +238,8 @@ def _create_volume(module, volume_server, datacenter, name, client):
     if module.check_mode:
         module.exit_json(changed=True)
 
-    if image:
-        try:
-            if uuid_match.match(image):
-                image_id = image
-            else:
-                image_id = _resolve_image(image, location, disk_type, client)
-
-            if not image_id:
-                module.fail_json(
-                    msg="Could not find the image. Please provide either image_id, either image alias and disk_type "
-                        "parameters")
-        except Exception as e:
-            module.fail_json(
-                msg="Could not find the image. Please provide either image_id, either image alias and disk_type "
-                    "parameters. Error %s" % to_native(e))
-
     try:
         volume_properties = VolumeProperties(name=name, type=disk_type, size=size, availability_zone=availability_zone,
-                                             image=image_id,
                                              image_password=image_password, ssh_keys=ssh_keys,
                                              bus=bus,
                                              licence_type=licence_type, cpu_hot_plug=cpu_hot_plug,
@@ -274,6 +247,11 @@ def _create_volume(module, volume_server, datacenter, name, client):
                                              nic_hot_unplug=nic_hot_unplug, disc_virtio_hot_plug=disc_virtio_hot_plug,
                                              disc_virtio_hot_unplug=disc_virtio_hot_unplug, backupunit_id=backupunit_id,
                                              user_data=user_data)
+
+        if uuid_match.match(image):
+            volume_properties.image = image
+        else:
+            volume_properties.image_alias = image
 
         volume = Volume(properties=volume_properties)
 
@@ -294,11 +272,8 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
     name = module.params.get('name')
     size = module.params.get('size')
     bus = module.params.get('bus')
-    disk_type = module.params.get('disk_type')
     availability_zone = module.params.get('availability_zone')
     licence_type = module.params.get('licence_type')
-    image = module.params.get('image')
-    location = module.params.get('location')
     cpu_hot_plug = module.params.get('cpu_hot_plug')
     ram_hot_plug = module.params.get('ram_hot_plug')
     nic_hot_plug = module.params.get('nic_hot_plug')
@@ -314,12 +289,6 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
         module.exit_json(changed=True)
 
     try:
-        if image:
-            if uuid_match.match(image):
-                image_id = image
-            else:
-                image_id = _resolve_image(image, location, disk_type, api_client)
-
         volume_properties = VolumeProperties(name=name, size=size, availability_zone=availability_zone,
                                              image=image_id, bus=bus,
                                              cpu_hot_plug=cpu_hot_plug, ram_hot_plug=ram_hot_plug,
@@ -612,7 +581,6 @@ def main():
             name=dict(type='str'),
             size=dict(type='int', default=10),
             image=dict(type='str'),
-            location=dict(type='str'),
             backupunit_id=dict(type='str'),
             user_data=dict(type='str'),
             image_password=dict(type='str', default=None, no_log=True),

--- a/tests/attach-volume-test.yml
+++ b/tests/attach-volume-test.yml
@@ -55,3 +55,9 @@
       register: disk
       tags:
         - create
+
+    - name: Remove datacenter
+      datacenter:
+        name: "{{ datacenter }}"
+        state: absent
+        wait: true

--- a/tests/server-test.yml
+++ b/tests/server-test.yml
@@ -26,7 +26,7 @@
          volume_availability_zone: ZONE_3
          volume_size: 5
          cpu_family: INTEL_SKYLAKE
-         disk_type: HDD
+         disk_type: SSD Standard
          image: "{{ image_alias }}"
          image_password: "{{ password }}"
          location: "{{ location }}"

--- a/tests/snapshot-test.yml
+++ b/tests/snapshot-test.yml
@@ -23,7 +23,6 @@
         image_password: "{{ password }}"
         availability_zone: ZONE_3
         auto_increment: no
-        location: "{{ location }}"
         state: present
 
     - name: Create snapshot

--- a/tests/volume-test.yml
+++ b/tests/volume-test.yml
@@ -18,7 +18,6 @@
       volume:
         datacenter: "{{ datacenter }}"
         name: "{{ name }} %02d"
-        location: "{{ location }}"
         disk_type: "SSD Premium"
         image: "{{ image_alias }}"
         image_password: "{{ password }}"

--- a/tests/volume-test.yml
+++ b/tests/volume-test.yml
@@ -19,7 +19,7 @@
         datacenter: "{{ datacenter }}"
         name: "{{ name }} %02d"
         location: "{{ location }}"
-        disk_type: "HDD"
+        disk_type: "SSD Premium"
         image: "{{ image_alias }}"
         image_password: "{{ password }}"
         count: 2


### PR DESCRIPTION
## What does this fix or implement?

* fix create volume bug that forced disk_type to be always `HDD` 
* fix #4: add support for SSD storage _(new options for volume storage type: SSD Standard, SSD Premium)_ - **SSD Premium is the default** if disk_type=SSD



## Checklist
- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [x] Github Issue linked if any



