### PR TITLE
fix: add support for SSD storages v6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-            ref: release/v6
 
       - name: Setup Python ${{ env.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-            ref: release/v6
 
       - name: Setup Python ${{ env.python-version }}
         uses: actions/setup-python@v2

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -118,7 +118,7 @@ The following parameters are supported:
 | count | no | integer | 1 | The number of servers to create. |
 | name | **yes**/no | string |  | The name of the server\(s\). Required only for `state='present'`. |
 | template_uuid | **yes**/no | string |  | The UUID of the template for creating a CUBE server; the available templates for CUBE servers can be found on the templates resource. Required only for state = 'present'. |
-| image | **yes**/no | string |  | Image, snapshot ID or image alias to be used as template for the volume of the server. If image alias is used, provide the location and the disk_type too, in order to identify the correct image ID.  Required only for `state='present'`. |
+| image | **yes**/no | string |  | Image, snapshot ID or image alias to be used as template for the volume of the server. |
 | image\_password | no | string |  | Password set for the administrative user. |
 | ssh\_keys | no | list | none | List of public SSH keys allowing access to the server. |
 | datacenter | **yes** | string | none | The datacenter where the server is located. |
@@ -127,7 +127,7 @@ The following parameters are supported:
 | cpu\_family | no | string | AMD\_OPTERON | The CPU family type of the server: **AMD\_OPTERON**, INTEL\_XEON, INTEL\_SKYLAKE |
 | availability\_zone | no | string | AUTO | The availability zone assigned to the server: **AUTO**, ZONE\_1, ZONE\_2 |
 | volume\_size | no | integer | 10 | The size in GB of the boot volume. |
-| disk\_type | no | string | HDD | The type of disk the volume will use: **HDD**, SSD |
+| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD, SSD Standard or SSD Premium. If `SSD` is provided, it will automatically use `SSD Premium` |
 | volume\_availability\_zone | no | string | AUTO | The storage availability zone assigned to the volume: **AUTO**, ZONE\_1, ZONE\_2, ZONE\_3 |
 | bus | no | string | VIRTIO | The bus type for the volume: **VIRTIO**, IDE |
 | type | **yes** | string | ENTERPRISE | The type of the server. Accepted values: ENTERPRISE or CUBE |

--- a/docs/api/compute-engine/volume.md
+++ b/docs/api/compute-engine/volume.md
@@ -59,13 +59,12 @@ The following parameters are supported:
 | name | **yes**/no | string |  | The name of the volume. You can enumerate the names using auto\_increment. |
 | size | no | integer | 10 | The size of the volume in GB. |
 | bus | no | string | VIRTIO | The bus type of the volume: **VIRTIO**, IDE |
-| image | no | string |  | Image, snapshot ID or image alias to be used as template for this volume. If image alias is used, provide the location and the disk_type too, in order to identify the correct image ID. |
-| location | no | string |  | The location of the provided image. This parameter is required only when the image alias is used instead of an UUID for the image. The available locations are: us/las, us/ewr, de/fra, de/fkb, de/txl, gb/lhr |
+| image | no | string |  | Image, snapshot ID or image alias to be used as template for this volume. |
 | backupunit\_id | no | string |  | The uuid of the Backup Unit that user has access to. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property.. |
 | user\_data | no | string |  | The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' that has cloud-init compatibility in conjunction with this property. |
 | image\_password | no | string |  | Password set for the administrative user. |
 | ssh\_keys | no | list |  | Public SSH keys allowing access to the server. |
-| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD |
+| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD, SSD Standard or SSD Premium. If `SSD` is provided, it will automatically use `SSD Premium` |
 | licence\_type | no | string |  | The licence type for the volume. This is used when the image is non-standard: LINUX, WINDOWS, **UNKNOWN**, OTHER, WINDOWS2016 |
 | availability\_zone | no | string | AUTO | The storage availability zone assigned to the volume: **AUTO**, ZONE\_1, ZONE\_2, ZONE\_3 |
 | count | no | integer | 1 | The number of volumes to create. |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -128,3 +128,14 @@
 ### Misc:
 
 * docs: updated the name of the module in examples
+
+
+## 6.0.1
+
+### Bug fixes:
+
+* fix create volume bug that forced disk_type to be always `HDD` 
+
+### Enhancements:
+
+* add support for SSD storage _(new options for volume storage type: SSD Standard, SSD Premium)_ - **SSD Premium is the default** if disk_type=SSD

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ namespace: ionoscloudsdk
 name: ionoscloud
 
 # The version of the collection.
-version: 6.0.0
+version: 6.0.1
 
 readme: README.md
 

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -401,10 +401,11 @@ def _create_machine(module, client, datacenter, name):
                                              ssh_keys=ssh_keys,
                                              bus=bus)
 
-        if uuid_match.match(image):
-            volume_properties.image = image
-        else:
-            volume_properties.image_alias = image
+        if image:
+            if uuid_match.match(image):
+                volume_properties.image = image
+            else:
+                volume_properties.image_alias = image
 
         volume = Volume(properties=volume_properties)
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -183,7 +183,9 @@ from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_native
 
 DISK_TYPES = ['HDD',
-              'SSD']
+              'SSD',
+              'SSD Premium',
+              'SSD Standard']
 
 BUS_TYPES = ['VIRTIO',
              'IDE']
@@ -212,22 +214,9 @@ def _get_request_id(headers):
                         "header 'location': '{location}'".format(location=headers['location']))
 
 
-def _resolve_image(image_alias, location, disk_type, client):
-    image_client = ionoscloud.api.ImagesApi(api_client=client)
-    images = image_client.images_get(depth=5)
-
-    if len(images.items) > 0:
-        for image in images.items:
-            if image_alias in image.properties.image_aliases and location == image.properties.location and disk_type == image.properties.image_type:
-                return image.id
-
-    return None
-
-
 def _create_volume(module, volume_server, datacenter, name, client):
     size = module.params.get('size')
     bus = module.params.get('bus')
-    location = module.params.get('location')
     image = module.params.get('image')
     image_password = module.params.get('image_password')
     ssh_keys = module.params.get('ssh_keys')
@@ -244,30 +233,24 @@ def _create_volume(module, volume_server, datacenter, name, client):
     user_data = module.params.get('user_data')
     wait_timeout = module.params.get('wait_timeout')
     wait = module.params.get('wait')
-    image_id = None
 
     if module.check_mode:
         module.exit_json(changed=True)
 
-    if image:
-        try:
-            if uuid_match.match(image):
-                image_id = image
-            else:
-                image_id = _resolve_image(image, location, disk_type, client)
-
-            if not image_id:
-                module.fail_json(
-                    msg="Could not find the image. Please provide either image_id, either image alias and disk_type "
-                        "parameters")
-        except Exception as e:
-            module.fail_json(
-                msg="Could not find the image. Please provide either image_id, either image alias and disk_type "
-                    "parameters. Error %s" % to_native(e))
-
-
     try:
-        volume_properties = VolumeProperties(name=name, type=disk_type, size=size, availability_zone=availability_zone, image=image_id, image_password=image_password, ssh_keys=ssh_keys, bus=bus, licence_type=licence_type, cpu_hot_plug=cpu_hot_plug, ram_hot_plug=ram_hot_plug, nic_hot_plug=nic_hot_plug, nic_hot_unplug=nic_hot_unplug, disc_virtio_hot_plug=disc_virtio_hot_plug, disc_virtio_hot_unplug=disc_virtio_hot_unplug, backupunit_id=backupunit_id, user_data=user_data)
+        volume_properties = VolumeProperties(name=name, type=disk_type, size=size, availability_zone=availability_zone,
+                                             image_password=image_password, ssh_keys=ssh_keys,
+                                             bus=bus,
+                                             licence_type=licence_type, cpu_hot_plug=cpu_hot_plug,
+                                             ram_hot_plug=ram_hot_plug, nic_hot_plug=nic_hot_plug,
+                                             nic_hot_unplug=nic_hot_unplug, disc_virtio_hot_plug=disc_virtio_hot_plug,
+                                             disc_virtio_hot_unplug=disc_virtio_hot_unplug, backupunit_id=backupunit_id,
+                                             user_data=user_data)
+
+        if uuid_match.match(image):
+            volume_properties.image = image
+        else:
+            volume_properties.image_alias = image
 
         volume = Volume(properties=volume_properties)
 
@@ -285,13 +268,11 @@ def _create_volume(module, volume_server, datacenter, name, client):
 
 
 def _update_volume(module, volume_server, api_client, datacenter, volume_id):
+    name = module.params.get('name')
     size = module.params.get('size')
     bus = module.params.get('bus')
-    disk_type = module.params.get('disk_type')
     availability_zone = module.params.get('availability_zone')
     licence_type = module.params.get('licence_type')
-    image = module.params.get('image')
-    location = module.params.get('location')
     cpu_hot_plug = module.params.get('cpu_hot_plug')
     ram_hot_plug = module.params.get('ram_hot_plug')
     nic_hot_plug = module.params.get('nic_hot_plug')
@@ -307,16 +288,12 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
         module.exit_json(changed=True)
 
     try:
-        if image:
-            if uuid_match.match(image):
-                image_id = image
-            else:
-                image_id = _resolve_image(image, location, disk_type, api_client)
-        volume_properties = VolumeProperties(size=size, availability_zone=availability_zone, image=image_id, bus=bus,
+        volume_properties = VolumeProperties(name=name, size=size, availability_zone=availability_zone,
+                                             bus=bus,
                                              cpu_hot_plug=cpu_hot_plug, ram_hot_plug=ram_hot_plug,
                                              nic_hot_plug=nic_hot_plug, nic_hot_unplug=nic_hot_unplug,
                                              disc_virtio_hot_plug=disc_virtio_hot_plug,
-                                             disc_virtio_hot_unplug=disc_virtio_hot_unplug)
+                                             disc_virtio_hot_unplug=disc_virtio_hot_unplug, licence_type=licence_type)
         volume = Volume(properties=volume_properties)
         response = volume_server.datacenters_volumes_put_with_http_info(
             datacenter_id=datacenter,
@@ -408,6 +385,7 @@ def create_volume(module, client):
     for name in names:
         # Skip volume creation if a volume with the same name already exists.
         if _get_instance_id(volume_list, name):
+            volumes.append(_get_resource(volume_list, name))
             continue
 
         create_response = _create_volume(module, volume_server, str(datacenter), name, client)
@@ -584,6 +562,16 @@ def _get_instance_id(instance_list, identity):
     return None
 
 
+def _get_resource(instance_list, identity):
+    """
+    Return instance UUID by name or ID, if found.
+    """
+    for i in instance_list.items:
+        if identity in (i.properties.name, i.id):
+            return i
+    return None
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -592,7 +580,6 @@ def main():
             name=dict(type='str'),
             size=dict(type='int', default=10),
             image=dict(type='str'),
-            location=dict(type='str'),
             backupunit_id=dict(type='str'),
             user_data=dict(type='str'),
             image_password=dict(type='str', default=None, no_log=True),
@@ -638,7 +625,7 @@ def main():
     password = module.params.get('password')
     api_url = module.params.get('api_url')
 
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % (__version__, sdk_version)
 
     conf = {
         'username': username,

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -246,11 +246,11 @@ def _create_volume(module, volume_server, datacenter, name, client):
                                              nic_hot_unplug=nic_hot_unplug, disc_virtio_hot_plug=disc_virtio_hot_plug,
                                              disc_virtio_hot_unplug=disc_virtio_hot_unplug, backupunit_id=backupunit_id,
                                              user_data=user_data)
-
-        if uuid_match.match(image):
-            volume_properties.image = image
-        else:
-            volume_properties.image_alias = image
+        if image:
+            if uuid_match.match(image):
+                volume_properties.image = image
+            else:
+                volume_properties.image_alias = image
 
         volume = Volume(properties=volume_properties)
 
@@ -279,7 +279,6 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
     nic_hot_unplug = module.params.get('nic_hot_unplug')
     disc_virtio_hot_plug = module.params.get('disc_virtio_hot_plug')
     disc_virtio_hot_unplug = module.params.get('disc_virtio_hot_unplug')
-    image_id = None
 
     wait_timeout = module.params.get('wait_timeout')
     wait = module.params.get('wait')

--- a/tests/server-test.yml
+++ b/tests/server-test.yml
@@ -26,7 +26,7 @@
          volume_availability_zone: ZONE_3
          volume_size: 5
          cpu_family: INTEL_SKYLAKE
-         disk_type: HDD
+         disk_type: SSD Standard
          image: "{{ image_alias }}"
          image_password: "{{ password }}"
          location: "{{ location }}"

--- a/tests/snapshot-test.yml
+++ b/tests/snapshot-test.yml
@@ -23,7 +23,6 @@
         image_password: "{{ password }}"
         availability_zone: ZONE_3
         auto_increment: no
-        location: "{{ location }}"
         state: present
 
     - name: Create snapshot

--- a/tests/volume-test.yml
+++ b/tests/volume-test.yml
@@ -18,7 +18,6 @@
       volume:
         datacenter: "{{ datacenter }}"
         name: "{{ name }} %02d"
-        location: "{{ location }}"
         disk_type: SSD Premium
         image: "{{ image_alias }}"
         image_password: "{{ password }}"

--- a/tests/volume-test.yml
+++ b/tests/volume-test.yml
@@ -19,7 +19,7 @@
         datacenter: "{{ datacenter }}"
         name: "{{ name }} %02d"
         location: "{{ location }}"
-        disk_type: "HDD"
+        disk_type: SSD Premium
         image: "{{ image_alias }}"
         image_password: "{{ password }}"
         count: 2


### PR DESCRIPTION
## What does this fix or implement?

* fix create volume bug that forced disk_type to be always `HDD` 
* fix #4: add support for SSD storage _(new options for volume storage type: SSD Standard, SSD Premium)_ - **SSD Premium is the default** if disk_type=SSD



## Checklist
- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Tests added or updated
- [x] Documentation updated
- [x] Changelog updated and version incremented (label: upcoming release)
- [x] Github Issue linked if any



