### PR TITLE
Feat (v6): s3key idempotency (#67)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,6 +122,10 @@ jobs:
         run: |
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/s3key-test.yml
 
+      - name: Run S3key test for idempotency
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/s3key-test-idempotency.yml
+
       - name: Run Server test
         run: |
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/server-test.yml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,10 +52,29 @@ jobs:
         run: |
           python3 -m pip list
 
+      - name: Run Datacenter test
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/datacenter-test.yml
+
+<<<<<<< HEAD
+=======
+      - name: Run K8s Nodepool test
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/k8s-cluster-nodepool-test.yml
+
+      - name: Run User test
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/user-test.yml
+
+      - name: Run Group test
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/group-test.yml
+
       - name: Run Postgres Cluster Info test
         run: |
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-cluster-info-test.yml
 
+>>>>>>> 00db8fa... feat: generate docs (#61)
       - name: Run Postgres Cluster Backup Info test
         run: |
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-backup-info-test.yml
@@ -64,12 +83,15 @@ jobs:
         run: |
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-cluster-test.yml
 
-      - name: Run Datacenter test
+      - name: Run Backupunit test
         run: |
+<<<<<<< HEAD
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/datacenter-test.yml
 
       - name: Run Backupunit test
         run: |
+=======
+>>>>>>> 00db8fa... feat: generate docs (#61)
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/backupunit-test.yml
           
       - name: Run Nic Flowlog test
@@ -140,15 +162,6 @@ jobs:
         run: |
           ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/k8s-cluster-test.yml
 
-      - name: Run K8s Nodepool test
+      - name: Run Private K8s Cluster test
         run: |
-          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/k8s-cluster-nodepool-test.yml
-
-      - name: Run User test
-        run: |
-          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/user-test.yml
-
-      - name: Run Group test
-        run: |
-          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/group-test.yml
-
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/private-k8s-cluster-test.yml

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -59,21 +59,6 @@ jobs:
         run: |
          python3 -m pip list
 
-      - name: Run Postgres Cluster Info test
-        if: github.event.inputs.test == 'yes'
-        run: |
-          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-cluster-info-test.yml
-
-      - name: Run Postgres Cluster Backup Info test
-        if: github.event.inputs.test == 'yes'
-        run: |
-          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-backup-info-test.yml
-
-      - name: Run Postgres Cluster tests
-        if: github.event.inputs.test == 'yes'
-        run: |
-         ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-cluster-test.yml
-
       - name: Run Datacenter tests
         if: github.event.inputs.test == 'yes'
         run: |
@@ -198,6 +183,21 @@ jobs:
         if: github.event.inputs.test == 'yes'
         run: |
          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/group-test.yml
+
+      - name: Run Postgres Cluster Info test
+        if: github.event.inputs.test == 'yes'
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-cluster-info-test.yml
+
+      - name: Run Postgres Cluster Backup Info test
+        if: github.event.inputs.test == 'yes'
+        run: |
+          ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-backup-info-test.yml
+
+      - name: Run Postgres Cluster tests
+        if: github.event.inputs.test == 'yes'
+        run: |
+         ansible-playbook /home/runner/work/module-ansible/module-ansible/tests/postgres-cluster-test.yml
 
 
   publish:

--- a/docs/api/compute-engine/cube_template.md
+++ b/docs/api/compute-engine/cube_template.md
@@ -1,29 +1,36 @@
-# Cube template
+# cube_template
+
+This is a simple module that supports retrieving one or more Cube templates
 
 ## Example Syntax
 
+
 ```yaml
+
     - name: List templates
       cube_template:
         state: present
       register: template_list
+
+    - name: Debug - Show Templates List
+      debug:
+        msg: "{{  template_list.template }}"
 
     - name: Get template by template id
       cube_template:
         template_id: "{{ template_list.template['items'][0]['id'] }}"
       register: template_response
 
+    - name: Debug - Show Template
+      debug:
+        msg: "{{ template_response.template }}"
+  
 ```
 
-## Parameter Reference
-
-The following parameters are supported:
-
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| template_id | no | string |  | The UUID of the template. If missing, the module will return all available templates.  |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| state | no | string | present | Indicate desired state of the resource: only **present** available. |
-
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | template_id | False | str |  | The ID of the template. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | state | False | str | present | Indicate desired state of the resource. |

--- a/docs/api/compute-engine/datacenter.md
+++ b/docs/api/compute-engine/datacenter.md
@@ -1,8 +1,43 @@
-# Datacenter
+# datacenter
+
+This is a simple module that supports creating or removing vDCs. A vDC is required before you can create servers. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+# Create a Datacenter
+  - name: Create datacenter
+    datacenter:
+      name: "Example DC"
+      description: "description"
+      location: de/fra
+    register: datacenter_response
+  
+# Update a datacenter description
+  - name: Update datacenter
+    datacenter:
+      id: "{{ datacenter_response.datacenter.id }}"
+      name: "Example DC"
+      description: "description - RENAMED"
+      state: update
+    register: updated_datacenter
+  
+# Destroy a Datacenter. This will remove all servers, volumes, and other objects in the datacenter.
+  - name: Remove datacenter
+    datacenter:
+      id: "{{ datacenter_response.datacenter.id }}"
+      name: "Example DC"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+<<<<<<< HEAD
     - name: Create datacenter
       datacenter:
         name: "{{ datacenter }}"
@@ -28,21 +63,89 @@
         name: "{{ datacenter }}"
         state: absent
       register: deleted_datacenter
+=======
+  # Create a Datacenter
+  - name: Create datacenter
+    datacenter:
+      name: "Example DC"
+      description: "description"
+      location: de/fra
+    register: datacenter_response
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **present**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the virtual datacenter. |
+  | description | False | str |  | The description of the virtual datacenter. |
+  | location | True | str | us/las | The datacenter location. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes** | string |  | The name of the datacenter. |
-| location | no | string | us/las | The datacenter location: us/las, us/ewr, de/fra, de/fkb, de/txl, gb/lhr |
-| description | no | string |  | The description of the datacenter. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+&nbsp;
+# state: **absent**
+```yaml
+  # Destroy a Datacenter. This will remove all servers, volumes, and other objects in the datacenter.
+  - name: Remove datacenter
+    datacenter:
+      id: "{{ datacenter_response.datacenter.id }}"
+      name: "Example DC"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the virtual datacenter. |
+  | id | False | str |  | The ID of the virtual datacenter. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update a datacenter description
+  - name: Update datacenter
+    datacenter:
+      id: "{{ datacenter_response.datacenter.id }}"
+      name: "Example DC"
+      description: "description - RENAMED"
+      state: update
+    register: updated_datacenter
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the virtual datacenter. |
+  | id | False | str |  | The ID of the virtual datacenter. |
+  | description | False | str |  | The description of the virtual datacenter. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/firewall_rule.md
+++ b/docs/api/compute-engine/firewall_rule.md
@@ -1,0 +1,185 @@
+# firewall_rule
+
+This module allows you to create, update or remove a firewall rule.
+
+## Example Syntax
+
+
+```yaml
+# Create a firewall rule
+- name: Create SSH firewall rule
+  firewall_rule:
+    datacenter: Virtual Datacenter
+    server: node001
+    nic: 7341c2454f
+    name: Allow SSH
+    protocol: TCP
+    source_ip: 0.0.0.0
+    port_range_start: 22
+    port_range_end: 22
+    state: present
+
+- name: Create ping firewall rule
+  firewall_rule:
+    datacenter: Virtual Datacenter
+    server: node001
+    nic: 7341c2454f
+    name: Allow Ping
+    protocol: ICMP
+    source_ip: 0.0.0.0
+    icmp_type: 8
+    icmp_code: 0
+    state: present
+  
+# Update a firewall rule
+- name: Allow SSH access
+  firewall_rule:
+      datacenter: Virtual Datacenter
+      server: node001
+      nic: 7341c2454f
+      name: Allow Ping
+      source_ip: 162.254.27.217
+      source_mac: 01:23:45:67:89:00
+      state: update
+  
+# Remove a firewall rule
+- name: Remove public ping firewall rule
+  firewall_rule:
+    datacenter: Virtual Datacenter
+    server: node001
+    nic: aa6c261b9c
+    name: Allow Ping
+    state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  # Create a firewall rule
+- name: Create SSH firewall rule
+  firewall_rule:
+    datacenter: Virtual Datacenter
+    server: node001
+    nic: 7341c2454f
+    name: Allow SSH
+    protocol: TCP
+    source_ip: 0.0.0.0
+    port_range_start: 22
+    port_range_end: 22
+    state: present
+
+- name: Create ping firewall rule
+  firewall_rule:
+    datacenter: Virtual Datacenter
+    server: node001
+    nic: 7341c2454f
+    name: Allow Ping
+    protocol: ICMP
+    source_ip: 0.0.0.0
+    icmp_type: 8
+    icmp_code: 0
+    state: present
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | server | True | str |  | The server name or UUID. |
+  | nic | True | str |  | The NIC name or UUID. |
+  | name | True | str |  | The name or UUID of the firewall rule. |
+  | protocol | True | str |  | The protocol for the firewall rule. |
+  | source_mac | False | str |  | Only traffic originating from the respective MAC address is allowed. No value allows all source MAC addresses. |
+  | source_ip | False | str |  | Only traffic originating from the respective IPv4 address is allowed. No value allows all source IPs. |
+  | target_ip | False | str |  | In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed.No value allows all target IPs. |
+  | port_range_start | False | int |  | Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Leave value empty to allow all ports. |
+  | port_range_end | False | int |  | Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Leave value empty to allow all ports. |
+  | icmp_type | False | int |  | Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. No value allows all types. |
+  | icmp_code | False | int |  | Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. No value allows all codes. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove a firewall rule
+- name: Remove public ping firewall rule
+  firewall_rule:
+    datacenter: Virtual Datacenter
+    server: node001
+    nic: aa6c261b9c
+    name: Allow Ping
+    state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | server | True | str |  | The server name or UUID. |
+  | nic | True | str |  | The NIC name or UUID. |
+  | name | True | str |  | The name or UUID of the firewall rule. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update a firewall rule
+- name: Allow SSH access
+  firewall_rule:
+      datacenter: Virtual Datacenter
+      server: node001
+      nic: 7341c2454f
+      name: Allow Ping
+      source_ip: 162.254.27.217
+      source_mac: 01:23:45:67:89:00
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | server | True | str |  | The server name or UUID. |
+  | nic | True | str |  | The NIC name or UUID. |
+  | name | True | str |  | The name or UUID of the firewall rule. |
+  | protocol | False | str |  | The protocol for the firewall rule. |
+  | source_mac | False | str |  | Only traffic originating from the respective MAC address is allowed. No value allows all source MAC addresses. |
+  | source_ip | False | str |  | Only traffic originating from the respective IPv4 address is allowed. No value allows all source IPs. |
+  | target_ip | False | str |  | In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed.No value allows all target IPs. |
+  | port_range_start | False | int |  | Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Leave value empty to allow all ports. |
+  | port_range_end | False | int |  | Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Leave value empty to allow all ports. |
+  | icmp_type | False | int |  | Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. No value allows all types. |
+  | icmp_code | False | int |  | Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. No value allows all codes. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/image.md
+++ b/docs/api/compute-engine/image.md
@@ -1,9 +1,17 @@
-# Image
+# image
+
+This is a simple module that supports updating or removing Images. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
     - name: Update image
+=======
+# Update an image
+  - name: Update image
+>>>>>>> 00db8fa... feat: generate docs (#61)
       image:
         image_id: "916b10ea-be31-11eb-b909-c608708a73fa"
         name: "CentOS-8.3.2011-x86_64-boot-renamed.iso"
@@ -21,31 +29,98 @@
         licence_type: "LINUX"
         cloud_init: V1
         state: update
-
-    - name: Delete image
+  
+# Destroy an image
+  - name: Delete image
       image:
         image_id: "916b10ea-be31-11eb-b909-c608708a73fa"
         state: absent
+  
 ```
+&nbsp;
 
-## Parameter Reference
+&nbsp;
 
-The following parameters are supported:
+<<<<<<< HEAD
+    - name: Delete image
+=======
+# state: **absent**
+```yaml
+  # Destroy an image
+  - name: Delete image
+>>>>>>> 00db8fa... feat: generate docs (#61)
+      image:
+        image_id: "916b10ea-be31-11eb-b909-c608708a73fa"
+        state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| image_id | **yes**/no | string |  | The ID of the image. Only required when state = `update` |
-| name | no | string |  | The resource name. |
-| description | no | string |  | Human readable description. |
-| cpu_hot_plug | no | boolean |  | Is capable of CPU hot plug (no reboot required). |
-| cpu_hot_unplug | no | boolean |  | Is capable of CPU hot unplug (no reboot required). |
-| ram_hot_plug | no | boolean |  | Is capable of memory hot plug (no reboot required). |
-| ram_hot_unplug | no | boolean |  | Is capable of memory hot unplug (no reboot required). |
-| nic_hot_plug | no | boolean |  | Is capable of nic hot plug (no reboot required). |
-| nic_hot_unplug | no | boolean |  | Is capable of nic hot unplug (no reboot required). |
-| disc_scsi_hot_plug | no | boolean |  | Is capable of SCSI drive hot plug (no reboot required). |
-| disc_scsi_hot_unplug | no | boolean |  | Is capable of SCSI drive hot unplug (no reboot required). This works only for non-Windows virtual Machines.. |
-| disc_virtio_hot_plug | no | boolean |  | Is capable of Virt-IO drive hot plug (no reboot required). |
-| disc_virtio_hot_unplug | no | boolean |  | Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines. |
-| licence_type | no | string |  | OS type of this Image. Accepted values: "UNKNOWN", "WINDOWS", "WINDOWS2016", "LINUX", "OTHER"|
-| cloud_init | no | string |  | Cloud init compatibility. Accepted values: "NONE", "V1" |
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | image_id | True | str |  | The ID of the image. |
+  | name | False | str |  | The name of the image. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update an image
+  - name: Update image
+      image:
+        image_id: "916b10ea-be31-11eb-b909-c608708a73fa"
+        name: "CentOS-8.3.2011-x86_64-boot-renamed.iso"
+        description: "An image used for testing the Ansible Module"
+        cpu_hot_plug: true
+        cpu_hot_unplug: false
+        ram_hot_plug: true
+        ram_hot_unplug: true
+        nic_hot_plug: true
+        nic_hot_unplug: true
+        disc_virtio_hot_plug: true
+        disc_virtio_hot_unplug: true
+        disc_scsi_hot_plug: true
+        disc_scsi_hot_unplug: false
+        licence_type: "LINUX"
+        cloud_init: V1
+        state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | image_id | True | str |  | The ID of the image. |
+  | name | False | str |  | The name of the image. |
+  | description | False | str |  | The description of the image. |
+  | cpu_hot_plug | False | bool |  | Hot-plug capable CPU (no reboot required). |
+  | cpu_hot_unplug | False | bool |  | Hot-unplug capable CPU (no reboot required). |
+  | ram_hot_plug | False | bool |  | Hot-plug capable RAM (no reboot required) |
+  | ram_hot_unplug | False | bool |  | Hot-unplug capable RAM (no reboot required). |
+  | nic_hot_plug | False | bool |  | Hot-plug capable NIC (no reboot required). |
+  | nic_hot_unplug | False | bool |  | Hot-unplug capable NIC (no reboot required) |
+  | disc_scsi_hot_plug | False | bool |  | Hot-plug capable SCSI drive (no reboot required). |
+  | disc_scsi_hot_unplug | False | bool |  | Hot-unplug capable SCSI drive (no reboot required). Not supported with Windows VMs. |
+  | disc_virtio_hot_plug | False | bool |  | Hot-plug capable Virt-IO drive (no reboot required). |
+  | disc_virtio_hot_unplug | False | bool |  | Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs. |
+  | licence_type | True | str |  | OS type for this image. |
+  | cloud_init | False | str |  | Cloud init compatibility. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/ipblock.md
+++ b/docs/api/compute-engine/ipblock.md
@@ -1,8 +1,40 @@
-# IpBlock
+# ipblock
+
+This module allows you to create or remove an IPBlock.
 
 ## Example Syntax
 
+
 ```yaml
+# Create an IPBlock
+- name: Create IPBlock
+  ipblock:
+    name: staging
+    location: us/ewr
+    size: 2
+    state: present
+  
+# Update an IPBlock
+- name: Update ipblock
+  ipblock:
+    name: "staging - updated"
+    location: "us/ewr"
+    state: update
+  
+# Remove an IPBlock
+- name: Remove IPBlock
+  ipblock:
+    name: staging
+    state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+<<<<<<< HEAD
     - name: Create ipblock
       ipblock:
         name:  "{{ name }}"
@@ -21,21 +53,83 @@
         name: "{{ name }}"
         state: absent
       register: delete_result
+=======
+  # Create an IPBlock
+- name: Create IPBlock
+  ipblock:
+    name: staging
+    location: us/ewr
+    size: 2
+    state: present
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **present**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name or ID of the IPBlock. |
+  | location | True | str | us/las | The IP Block location. |
+  | size | False | int | 1 | The number of IP addresses to allocate in the IPBlock. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes** | string |  | The name of the IPBlock. |
-| location | no | string | us/las | The IPBlock location: us/las, us/ewr, de/fra, de/fkb, de/txl, gb/lhr |
-| size | no | integer | 1 | The number of IP addresses to allocate in the IPBlock. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicates desired state of the resource: **present**, absent |
+&nbsp;
+# state: **update**
+```yaml
+  # Update an IPBlock
+- name: Update ipblock
+  ipblock:
+    name: "staging - updated"
+    location: "us/ewr"
+    state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name or ID of the IPBlock. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove an IPBlock
+- name: Remove IPBlock
+  ipblock:
+    name: staging
+    state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name or ID of the IPBlock. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/lan.md
+++ b/docs/api/compute-engine/lan.md
@@ -1,8 +1,45 @@
-# Lan
+# lan
+
+This module allows you to create or remove a LAN.
 
 ## Example Syntax
 
+
 ```yaml
+# Create a LAN
+- name: Create private LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    public: false
+    state: present
+  
+# Update a LAN
+- name: Update LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    public: true
+    ip_failover:
+          208.94.38.167: 1de3e6ae-da16-4dc7-845c-092e8a19fded
+          208.94.38.168: 8f01cbd3-bec4-46b7-b085-78bb9ea0c77c
+    state: update
+  
+# Remove a LAN
+- name: Remove LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+<<<<<<< HEAD
     - name: Create public LAN
       lan:
         datacenter: Virtual Datacenter
@@ -21,22 +58,95 @@
             - ip: "158.222.102.94"
               nic_uuid: "{{ nic.id }}"
         state: update
+=======
+  # Create a LAN
+- name: Create private LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    public: false
+    state: present
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **present**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | name | True | str |  | The name or ID of the LAN. |
+  | pcc_id | False | str |  | The ID of the PCC. |
+  | ip_failover | False | list |  | The IP failover group. |
+  | public | False | bool | False | If true, the LAN will have public Internet access. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| datacenter | **yes** | string |  | The datacenter in which to operate. |
-| name | **yes** | string |  | The name of the LAN. |
-| public | no | boolean | true | If true, the LAN will have public Internet access. |
-| ip\_failover | no | list |  | The IP failover list of group dictionaries containing IP addresses and NIC UUIDs. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove a LAN
+- name: Remove LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | name | True | str |  | The name or ID of the LAN. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update a LAN
+- name: Update LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    public: true
+    ip_failover:
+          208.94.38.167: 1de3e6ae-da16-4dc7-845c-092e8a19fded
+          208.94.38.168: 8f01cbd3-bec4-46b7-b085-78bb9ea0c77c
+    state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | name | True | str |  | The name or ID of the LAN. |
+  | pcc_id | False | str |  | The ID of the PCC. |
+  | ip_failover | False | list |  | The IP failover group. |
+  | public | False | bool | False | If true, the LAN will have public Internet access. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/nic.md
+++ b/docs/api/compute-engine/nic.md
@@ -1,8 +1,12 @@
-# Nic
+# nic
+
+This module allows you to create, update or remove a NIC.
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
     - name: Create private NIC
       nic:
           datacenter: Example
@@ -23,27 +27,137 @@
           - 158.222.103.24
         dhcp: false
         state: update
+=======
+# Create a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    lan: 2
+    wait_timeout: 500
+    state: present
+  
+# Update a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    name: 7341c2454f
+    lan: 1
+    ips:
+      - 158.222.103.23
+      - 158.222.103.24
+    dhcp: false
+    state: update
+  
+# Remove a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    name: 7341c2454f
+    wait_timeout: 500
+    state: absent
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+&nbsp;
 
-## Parameter Reference
+&nbsp;
 
-The following parameters are supported:
+# state: **present**
+```yaml
+  # Create a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    lan: 2
+    wait_timeout: 500
+    state: present
+  
+```
+### Available parameters for state **present**:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| datacenter | **yes** | string |  | The datacenter in which to operate. |
-| server | **yes** | string |  | The server name or UUID. |
-| name | no | string |  | The name of the NIC. |
-| id | **yes** | string |  | The id of the NIC. |
-| lan | **yes** | integer |  | The LAN to connect the NIC. The LAN will be created if it does not exist. Only required on creates. |
-| dhcp | no | boolean |  | Indicates if the NIC is using DHCP or not. |
-| nat | no | boolean |  | Allow the private IP address outbound Internet access. |
-| firewall\_active | no | boolean |  | Indicates if the firewall is active. |
-| ips | no | list |  | A list of IPs to be assigned to the NIC. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the NIC. |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | server | True | str |  | The server name or UUID. |
+  | dhcp | False | bool |  | Boolean value indicating if the NIC is using DHCP or not. |
+  | firewall_active | False | bool |  | Boolean value indicating if the firewall is active. |
+  | ips | False | list |  | A list of IPs to be assigned to the NIC. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    name: 7341c2454f
+    wait_timeout: 500
+    state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the NIC. |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | server | True | str |  | The server name or UUID. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    name: 7341c2454f
+    lan: 1
+    ips:
+      - 158.222.103.23
+      - 158.222.103.24
+    dhcp: false
+    state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the NIC. |
+  | id | False | str |  | The ID of the NIC. |
+  | datacenter | True | str |  | The datacenter name or UUID in which to operate. |
+  | server | True | str |  | The server name or UUID. |
+  | lan | False | str |  | The LAN to place the NIC on. You can pass a LAN that doesn't exist and it will be created. Required on create. |
+  | dhcp | False | bool |  | Boolean value indicating if the NIC is using DHCP or not. |
+  | firewall_active | False | bool |  | Boolean value indicating if the firewall is active. |
+  | ips | False | list |  | A list of IPs to be assigned to the NIC. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/nic_flowlog.md
+++ b/docs/api/compute-engine/nic_flowlog.md
@@ -1,8 +1,89 @@
-# Nic Flowlog
+# nic_flowlog
+
+This is a simple module that supports creating or removing NIC Flowlogs. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+- name: Create a nic flowlog
+  nic_flowlog:
+    name: "{{ name }}"
+    action: "ACCEPTED"
+    direction: "INGRESS"
+    bucket: "sdktest"
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+  register: flowlog_response
+  
+- name: Update a nic flowlog
+  nic_flowlog:
+    name: "{{ name }}"
+    action: "ALL"
+    direction: "INGRESS"
+    bucket: "sdktest"
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+    flowlog_id: "{{ flowlog_response.flowlog.id }}"
+  register: flowlog_update_response
+  
+- name: Delete a nic flowlog
+  nic_flowlog:
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+    flowlog_id: "{{ flowlog_response.flowlog.id }}"
+    name: "{{ name }}"
+    state: absent
+    wait: true
+  register: flowlog_delete_response
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  - name: Create a nic flowlog
+  nic_flowlog:
+    name: "{{ name }}"
+    action: "ACCEPTED"
+    direction: "INGRESS"
+    bucket: "sdktest"
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+  register: flowlog_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the Flowlog. |
+  | datacenter_id | True | str |  | The ID of the virtual datacenter. |
+  | server_id | True | str |  | The ID of the Server. |
+  | nic_id | True | str |  | The ID of the NIC. |
+  | action | True | str |  | Specifies the traffic action pattern. |
+  | direction | True | str |  | Specifies the traffic direction pattern. |
+  | bucket | True | str |  | S3 bucket name of an existing IONOS Cloud S3 bucket. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+<<<<<<< HEAD
     - name: Create a nic flowlog
       nic_flowlog:
         name: "{{ name }}"
@@ -35,27 +116,75 @@
         name: "{{ name }}"
         state: absent
       register: flowlog_delete_response
-
+=======
+  - name: Delete a nic flowlog
+  nic_flowlog:
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+    flowlog_id: "{{ flowlog_response.flowlog.id }}"
+    name: "{{ name }}"
+    state: absent
+    wait: true
+  register: flowlog_delete_response
+  
 ```
+### Available parameters for state **absent**:
+&nbsp;
+>>>>>>> 00db8fa... feat: generate docs (#61)
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the Flowlog. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | datacenter_id | True | str |  | The ID of the virtual datacenter. |
+  | server_id | True | str |  | The ID of the Server. |
+  | nic_id | True | str |  | The ID of the NIC. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes**/no | string |  | The name of the Flowlog. Required only for state = 'present'. |
-| action | **yes**/no | string |  | Specifies the traffic action pattern. Accepted values: "ACCEPTED", "REJECTED" or "ALL". Required only for state = 'present'.|
-| direction | **yes**/no | string |  | Specifies the traffic direction pattern. Accepted values: "INGRESS", "EGRESS", "BIDIRECTIONAL". Required only for state = 'present'. |
-| bucket | **yes**/no | string |  | S3 bucket name of an existing IONOS Cloud S3 bucket. Required only for state = 'present'. |
-| datacenter_id | **yes** | string |  | The ID of the datacenter. |
-| server_id | **yes** | string |  | The ID of the server. |
-| flowlog_id | **yes**/no | string |  | The ID of the flowlog. Required when state = 'update' or state = 'absent'.|
-| nic_id | **yes** | string |  | The ID of the Nic. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+&nbsp;
+# state: **update**
+```yaml
+  - name: Update a nic flowlog
+  nic_flowlog:
+    name: "{{ name }}"
+    action: "ALL"
+    direction: "INGRESS"
+    bucket: "sdktest"
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+    flowlog_id: "{{ flowlog_response.flowlog.id }}"
+  register: flowlog_update_response
+  
+```
+### Available parameters for state **update**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the Flowlog. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | datacenter_id | True | str |  | The ID of the virtual datacenter. |
+  | server_id | True | str |  | The ID of the Server. |
+  | nic_id | True | str |  | The ID of the NIC. |
+  | action | False | str |  | Specifies the traffic action pattern. |
+  | direction | False | str |  | Specifies the traffic direction pattern. |
+  | bucket | False | str |  | S3 bucket name of an existing IONOS Cloud S3 bucket. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/pcc.md
+++ b/docs/api/compute-engine/pcc.md
@@ -1,8 +1,39 @@
-# Private cross connect
+# pcc
+
+This is a simple module that supports creating or removing Private Cross Connects. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create pcc
+    pcc:
+      name: "{{ name }}"
+      description: "{{ description }}"
+  
+
+  - name: Update pcc
+    pcc:
+      pcc_id: "49e73efd-e1ea-11ea-aaf5-5254001a8838"
+      name: "{{ new_name }}"
+      description: "{{ new_description }}"
+      state: update
+  
+
+  - name: Remove pcc
+    pcc:
+      pcc_id: "2851af0b-e1ea-11ea-aaf5-5254001a8838"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+<<<<<<< HEAD
     - name: Create pcc
       pcc:
         name: "{{ name }}"
@@ -19,15 +50,83 @@
       pcc:
         pcc_id: "{{pcc.id}}"
         state: absent
+=======
+  
+  - name: Create pcc
+    pcc:
+      name: "{{ name }}"
+      description: "{{ description }}"
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **present**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the PCC. |
+  | description | True | str |  | The description of the PCC. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| pcc\_id | **yes**/no | string |  | The ID of the pcc. Required for state = 'update' or state = 'absent'. |
-| name | **yes**/no | string |  | The name of the pcc. Required only for state = 'present'. |
-| description | no | string |  | The description of the pcc. |
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Remove pcc
+    pcc:
+      pcc_id: "2851af0b-e1ea-11ea-aaf5-5254001a8838"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | pcc_id | True | str |  | The ID of the PCC. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  
+  - name: Update pcc
+    pcc:
+      pcc_id: "49e73efd-e1ea-11ea-aaf5-5254001a8838"
+      name: "{{ new_name }}"
+      description: "{{ new_description }}"
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the PCC. |
+  | pcc_id | True | str |  | The ID of the PCC. |
+  | description | False | str |  | The description of the PCC. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -1,9 +1,132 @@
-# Server
+# server
 
-## Example
+Create, update, destroy, update, start, stop, and reboot a Ionos virtual machine. When the virtual machine is created it can optionally wait for it to be 'running' before returning.
 
-### ENTERPRISE Server:
+## Example Syntax
+
+
 ```yaml
+# Provisioning example. This will create three servers and enumerate their names.
+    - server:
+        datacenter: Tardis One
+        name: web%02d.stackpointcloud.com
+        cores: 4
+        ram: 2048
+        volume_size: 50
+        cpu_family: INTEL_XEON
+        image: ubuntu:latest
+        location: us/las
+        count: 3
+        assign_public_ip: true
+  
+# Update Virtual machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - web001.stackpointcloud.com
+        - web002.stackpointcloud.com
+        cores: 4
+        ram: 4096
+        cpu_family: INTEL_XEON
+        availability_zone: ZONE_1
+        state: update
+  
+# Removing Virtual machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: absent
+  
+# Starting Virtual Machines.
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: running
+  
+# Stopping Virtual Machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: stopped
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **running**
+```yaml
+  # Starting Virtual Machines.
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: running
+  
+```
+### Available parameters for state **running**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **stopped**
+```yaml
+  # Stopping Virtual Machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: stopped
+  
+```
+### Available parameters for state **stopped**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **resume**
+```yaml
+<<<<<<< HEAD
     - name: Provision a server
       server:
          datacenter: "{{ datacenter }}"
@@ -54,95 +177,166 @@
          wait_timeout: "{{ timeout }}"
          state: running
          
-
+=======
+  
 ```
+### Available parameters for state **resume**:
+&nbsp;
 
-### CUBE Server
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
+&nbsp;
+
+&nbsp;
+# state: **suspend**
 ```yaml
-    - name: Provision a server
-      server:
-         datacenter: "{{ datacenter }}"
-         name: "{{ name }} %02d"
-         auto_increment: true
-         cpu_family: INTEL_SKYLAKE
-         disk_type: DAS
-         image: "912139a4-c283-11eb-a028-52d578831bb3"
-         image_password: "{{ password }}"
-         location: "de/txl"
-         count: 1
-         assign_public_ip: true
-         remove_boot_volume: true
-         template_uuid: "15c6dd2f-02d2-4987-b439-9a58dd59ecc3"
-         type: "CUBE"
-         wait: true
-         wait_timeout: "{{ wait_timeout }}"
-         state: present
-
-    - name: Update server
-      server:
-         datacenter: "{{ datacenter }}"
-         name: "{{ name }} - UPDATED"
-         instance_ids:
-           - "{{ name }} 01"
-         type: CUBE
-         wait: true
-         wait_timeout: "{{ wait_timeout }}"
-         state: update
-
-    - name: Suspend server
-      server:
-         datacenter: "{{ datacenter }}"
-         instance_ids:
-           - "{{ name }} 01"
-         wait_timeout: "{{ wait_timeout }}"
-         state: suspend
-
-    - name: Resume server
-      server:
-         datacenter: "{{ datacenter }}"
-         instance_ids:
-           - "{{ name }} 01"
-         wait_timeout: "{{ wait_timeout }}"
-         state: resume
-
+  
 ```
+### Available parameters for state **suspend**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
+>>>>>>> 00db8fa... feat: generate docs (#61)
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| auto\_increment | no | boolean | true | Whether or not to increment created servers. |
-| count | no | integer | 1 | The number of servers to create. |
-| name | **yes**/no | string |  | The name of the server\(s\). Required only for `state='present'`. |
-| template_uuid | **yes**/no | string |  | The UUID of the template for creating a CUBE server; the available templates for CUBE servers can be found on the templates resource. Required only for state = 'present'. |
-| image | **yes**/no | string |  | Image, snapshot ID or image alias to be used as template for the volume of the server. |
-| image\_password | no | string |  | Password set for the administrative user. |
-| ssh\_keys | no | list | none | List of public SSH keys allowing access to the server. |
-| datacenter | **yes** | string | none | The datacenter where the server is located. |
-| cores | no | integer | 2 | The number of CPU cores to allocate to the server. |
-| ram | no | integer | 2048 | The amount of memory to allocate to the server. |
-| cpu\_family | no | string | AMD\_OPTERON | The CPU family type of the server: **AMD\_OPTERON**, INTEL\_XEON, INTEL\_SKYLAKE |
-| availability\_zone | no | string | AUTO | The availability zone assigned to the server: **AUTO**, ZONE\_1, ZONE\_2 |
-| volume\_size | no | integer | 10 | The size in GB of the boot volume. |
-| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD, SSD Standard or SSD Premium. If `SSD` is provided, it will automatically use `SSD Premium` |
-| volume\_availability\_zone | no | string | AUTO | The storage availability zone assigned to the volume: **AUTO**, ZONE\_1, ZONE\_2, ZONE\_3 |
-| bus | no | string | VIRTIO | The bus type for the volume: **VIRTIO**, IDE |
-| type | **yes** | string | ENTERPRISE | The type of the server. Accepted values: ENTERPRISE or CUBE |
-| instance\_ids | **yes**/no | list |  | List of instance IDs or names. **Not required** for `state='present'`. |
-| location | no | string | us/las | The datacenter location used only if the module creates a default datacenter: us/las, us/ewr, de/fra, de/fkb, de/txl, gb/lhr |
-| boot_volume | no | string |  | The boot volume. |
-| boot_cdrom | no | string |  | The boot CDROM. |
-| assign\_public\_ip | no | boolean | false | This will assign the server to the public LAN. The LAN is created if no LAN exists with public Internet access. |
-| lan | no | string / integer | 1 | The LAN ID / Name for the server. |
-| nat | no | boolean | false | The private IP address has outbound access to the Internet. |
-| nic\_ips | no | list | false | List of IPs to be set in the included NIC of the server. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environment variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environment variable. |
-| wait | no | boolean | true | Wait for the instance to be in state 'running' before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| remove\_boot\_volume | no | boolean | true | Remove the boot volume of the server being deleted. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, running, stopped, update |
+&nbsp;
+# state: **absent**
+```yaml
+  # Removing Virtual machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the virtual machine. |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **present**
+```yaml
+  # Provisioning example. This will create three servers and enumerate their names.
+    - server:
+        datacenter: Tardis One
+        name: web%02d.stackpointcloud.com
+        cores: 4
+        ram: 2048
+        volume_size: 50
+        cpu_family: INTEL_XEON
+        image: ubuntu:latest
+        location: us/las
+        count: 3
+        assign_public_ip: true
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the virtual machine. |
+  | auto_increment | False | bool | True | Whether or not to increment a single number in the name for created virtual machines. |
+  | assign_public_ip | False | bool | False | This will assign the machine to the public LAN. If no LAN exists with public Internet access it is created. |
+  | image | True | str |  | The image alias or ID for creating the virtual machine. |
+  | image_password | False | str |  | Password set for the administrative user. |
+  | ssh_keys | False | list |  | Public SSH keys allowing access to the virtual machine. |
+  | volume_availability_zone | False | str |  | The storage availability zone assigned to the volume. |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | cores | False | int | 2 | The number of CPU cores to allocate to the virtual machine. |
+  | ram | False | int | 2048 | The amount of memory to allocate to the virtual machine. |
+  | cpu_family | False | str | AMD_OPTERON | The amount of memory to allocate to the virtual machine. |
+  | availability_zone | False | str | AUTO | The availability zone assigned to the server. |
+  | volume_size | False | int | 10 | The size in GB of the boot volume. |
+  | bus | False | str | VIRTIO | The bus type for the volume. |
+  | instance_ids | False | list |  | list of instance ids, currently only used when state='absent' to remove instances. |
+  | count | False | int | 1 | The number of virtual machines to create. |
+  | location | False | str | us/las | The datacenter location. Use only if you want to create the Datacenter or else this value is ignored. |
+  | lan | False | raw |  | The ID or name of the LAN you wish to add the servers to (can be a string or a number). |
+  | nat | False | bool | False | Boolean value indicating if the private IP address has outbound access to the public Internet. |
+  | remove_boot_volume | False | bool | True | Remove the bootVolume of the virtual machine you're destroying. |
+  | disk_type | False | str | HDD | The disk type for the volume. |
+  | nic_ips | False | list |  | The list of IPS for the NIC. |
+  | template_uuid | False | str |  | The template used when crating a CUBE server. |
+  | boot_volume | False | str |  | The volume used for boot. |
+  | boot_cdrom | False | str |  | The CDROM used for boot. |
+  | type | False | str | ENTERPRISE | The type of the virtual machine. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update Virtual machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - web001.stackpointcloud.com
+        - web002.stackpointcloud.com
+        cores: 4
+        ram: 4096
+        cpu_family: INTEL_XEON
+        availability_zone: ZONE_1
+        state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the virtual machine. |
+  | datacenter | True | str |  | The datacenter to provision this virtual machine. |
+  | cores | False | int | 2 | The number of CPU cores to allocate to the virtual machine. |
+  | ram | False | int | 2048 | The amount of memory to allocate to the virtual machine. |
+  | boot_volume | False | str |  | The volume used for boot. |
+  | boot_cdrom | False | str |  | The CDROM used for boot. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/snapshot.md
+++ b/docs/api/compute-engine/snapshot.md
@@ -1,8 +1,105 @@
-# Snapshot
+# snapshot
+
+This module allows you to create or remove a snapshot.
 
 ## Example Syntax
 
+
 ```yaml
+# Create a snapshot
+  - name: Create snapshot
+    snapshot:
+      datacenter: production DC
+      volume: master
+      name: boot volume image
+      state: present
+
+  
+# Update a snapshot
+  - name: Update snapshot
+    snapshot:
+      name: "boot volume image"
+      description: Ansible test snapshot - RENAME
+      state: update
+  
+# Restore a snapshot
+  - name: Restore snapshot
+    snapshot:
+      datacenter: production DC
+      volume: slave
+      name: boot volume image
+      state: restore
+  
+# Remove a snapshot
+  - name: Remove snapshot
+    snapshot:
+      name: master-Snapshot-11/30/2017
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  # Create a snapshot
+  - name: Create snapshot
+    snapshot:
+      datacenter: production DC
+      volume: master
+      name: boot volume image
+      state: present
+
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter in which the volumes reside. |
+  | volume | True | str |  | The name or UUID of the volume. |
+  | name | False | str |  | The name of the snapshot. |
+  | description | False | str |  | The description of the snapshot. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove a snapshot
+  - name: Remove snapshot
+    snapshot:
+      name: master-Snapshot-11/30/2017
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the snapshot. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+<<<<<<< HEAD
     - name: Create snapshot
       snapshot:
         datacenter: production DC
@@ -15,33 +112,69 @@
         volume: slave
         name: boot volume snapshot
         state: restore
+=======
+  # Update a snapshot
+  - name: Update snapshot
+    snapshot:
+      name: "boot volume image"
+      description: Ansible test snapshot - RENAME
+      state: update
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the snapshot. |
+  | licence_type | False | str |  | The license type used |
+  | cpu_hot_plug | False | bool |  | Hot-plug capable CPU (no reboot required). |
+  | cpu_hot_unplug | False | bool |  | Hot-unplug capable CPU (no reboot required). |
+  | ram_hot_plug | False | bool |  | Hot-plug capable RAM (no reboot required) |
+  | ram_hot_unplug | False | bool |  | Hot-unplug capable RAM (no reboot required). |
+  | nic_hot_plug | False | bool |  | Hot-plug capable NIC (no reboot required). |
+  | nic_hot_unplug | False | bool |  | Hot-unplug capable NIC (no reboot required) |
+  | disc_scsi_hot_plug | False | bool |  | Hot-plug capable SCSI drive (no reboot required). |
+  | disc_scsi_hot_unplug | False | bool |  | Hot-unplug capable SCSI drive (no reboot required). Not supported with Windows VMs. |
+  | disc_virtio_hot_plug | False | bool |  | Hot-plug capable Virt-IO drive (no reboot required). |
+  | disc_virtio_hot_unplug | False | bool |  | Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| datacenter | **yes**/no | string |  | The datacenter in which the volume resides. Required for `state='present'` or `state='restore'` to create or restore a snapshot. |
-| volume | **yes**/no | string |  | The volume to create or restore the snapshot. Required for `state='present'` or `state='restore'`. |
-| name | **yes**/no | string |  | The name of the snapshot. Required for `state='update'` or `state='absent'` to update or remove a snapshot. |
-| description | no | string |  | The description of the snapshot. |
-| licence\_type | no | string |  | The licence type for the volume. This is used when updating the snapshot: LINUX, WINDOWS, UNKNOWN, OTHER, WINDOWS2016 |
-| cpu\_hot\_plug | no | boolean |  | Indicates the volume is capable of CPU hot plug \(no reboot required\). |
-| cpu\_hot\_unplug | no | boolean |  | Indicates the volume is capable of CPU hot unplug \(no reboot required\). |
-| ram\_hot\_plug | no | boolean |  | Indicates the volume is capable of memory hot plug. |
-| ram\_hot\_unplug | no | boolean |  | Indicates the volume is capable of memory hot unplug. |
-| nic\_hot\_plug | no | boolean |  | Indicates the volume is capable of NIC hot plug. |
-| nic\_hot\_unplug | no | boolean |  | Indicates the volume is capable of NIC hot unplug. |
-| disc\_virtio\_hot\_plug | no | boolean |  | Indicates the volume is capable of VirtIO drive hot plug. |
-| disc\_virtio\_hot\_unplug | no | boolean |  | Indicates the volume is capable of VirtIO drive hot unplug. |
-| disc\_scsi\_hot\_plug | no | boolean |  | Indicates the volume is capable of SCSI drive hot plug. |
-| disc\_scsi\_hot\_unplug | no | boolean |  | Indicates the volume is capable of SCSI drive hot unplug. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environment variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environment variable. |
-| wait | no | boolean | true | Wait for the resource to be created before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, restore, update |
+&nbsp;
+# state: **restore**
+```yaml
+  # Restore a snapshot
+  - name: Restore snapshot
+    snapshot:
+      datacenter: production DC
+      volume: slave
+      name: boot volume image
+      state: restore
+  
+```
+### Available parameters for state **restore**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter in which the volumes reside. |
+  | volume | True | str |  | The name or UUID of the volume. |
+  | name | True | str |  | The name of the snapshot. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/compute-engine/volume.md
+++ b/docs/api/compute-engine/volume.md
@@ -1,8 +1,12 @@
-# Volume
+# volume
+
+Allows you to create, update or remove a volume from a Ionos datacenter.
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
     - name: Create volumes
       volume:
         datacenter: "{{ datacenter }}"
@@ -46,40 +50,158 @@
           - "{{ name }} 02"
         wait_timeout: 600
         state: absent
+=======
+# Create Multiple Volumes
+  - volume:
+    datacenter: Tardis One
+    name: vol%02d
+    count: 5
+    auto_increment: yes
+    wait_timeout: 500
+    state: present
+  
+# Update Volumes
+  - volume:
+      datacenter: Tardis One
+      instance_ids:
+        - 'vol01'
+        - 'vol02'
+      size: 50
+      bus: IDE
+      wait_timeout: 500
+      state: update
+  
+# Remove Volumes
+  - volume:
+    datacenter: Tardis One
+    instance_ids:
+      - 'vol01'
+      - 'vol02'
+    wait_timeout: 500
+    state: absent
+  
 ```
+&nbsp;
 
-## Parameter Reference
+&nbsp;
 
-The following parameters are supported:
+# state: **present**
+```yaml
+  # Create Multiple Volumes
+  - volume:
+    datacenter: Tardis One
+    name: vol%02d
+    count: 5
+    auto_increment: yes
+    wait_timeout: 500
+    state: present
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
+```
+### Available parameters for state **present**:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| datacenter | **yes** | string |  | The datacenter in which to create the volume. |
-| server | no | string |  | The server on which to attach the volume. |
-| name | **yes**/no | string |  | The name of the volume. You can enumerate the names using auto\_increment. |
-| size | no | integer | 10 | The size of the volume in GB. |
-| bus | no | string | VIRTIO | The bus type of the volume: **VIRTIO**, IDE |
-| image | no | string |  | Image, snapshot ID or image alias to be used as template for this volume. |
-| backupunit\_id | no | string |  | The uuid of the Backup Unit that user has access to. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property.. |
-| user\_data | no | string |  | The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on a new volume creation. It is mandatory to provide either 'public image' or 'imageAlias' that has cloud-init compatibility in conjunction with this property. |
-| image\_password | no | string |  | Password set for the administrative user. |
-| ssh\_keys | no | list |  | Public SSH keys allowing access to the server. |
-| disk\_type | no | string | HDD | The disk type of the volume: **HDD**, SSD, SSD Standard or SSD Premium. If `SSD` is provided, it will automatically use `SSD Premium` |
-| licence\_type | no | string |  | The licence type for the volume. This is used when the image is non-standard: LINUX, WINDOWS, **UNKNOWN**, OTHER, WINDOWS2016 |
-| availability\_zone | no | string | AUTO | The storage availability zone assigned to the volume: **AUTO**, ZONE\_1, ZONE\_2, ZONE\_3 |
-| count | no | integer | 1 | The number of volumes to create. |
-| auto\_increment | no | boolean | true | Whether or not to increment created servers. |
-| cpu_hot_plug | no | boolean |  | Is capable of CPU hot plug (no reboot required). |
-| ram_hot_plug | no | boolean |  | Is capable of memory hot plug (no reboot required). |
-| nic_hot_plug | no | boolean |  | Is capable of nic hot plug (no reboot required). |
-| nic_hot_unplug | no | boolean |  | Is capable of nic hot unplug (no reboot required). |
-| disc_virtio_hot_plug | no | boolean |  | Is capable of Virt-IO drive hot plug (no reboot required). |
-| disc_virtio_hot_unplug | no | boolean |  | Is capable of Virt-IO drive hot unplug (no reboot required). This works only for non-Windows virtual Machines. |
-| instance\_ids | **yes**/no | list |  | List of instance UUIDs or names. Required for `state='absent'` or `state='update'` to remove or update volumes. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environment variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environment variable. |
-| wait | no | boolean | true | Wait for the resource to be created before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter in which to create the volumes. |
+  | server | False | str |  | The server to which to attach the volume. |
+  | name | True | str |  | The name of the volumes. You can enumerate the names using auto_increment. |
+  | size | False | int | 10 | The size of the volume. |
+  | bus | False | str | VIRTIO | The bus type. |
+  | image | False | str |  | The image alias or ID for the volume. This can also be a snapshot image ID. |
+  | image_password | False | str |  | Password set for the administrative user. |
+  | ssh_keys | False | list |  | Public SSH keys allowing access to the virtual machine. |
+  | disk_type | False | str | HDD | The disk type of the volume. |
+  | licence_type | False | str | UNKNOWN | The licence type for the volume. This is used when the image is non-standard. |
+  | availability_zone | False | str |  | The storage availability zone assigned to the volume. |
+  | count | False | int | 1 | The number of volumes you wish to create. |
+  | auto_increment | False | bool | True | Whether or not to increment a single number in the name for created virtual machines. |
+  | backupunit_id | False | str |  | The ID of the backup unit that the user has access to. The property is immutable and is only allowed to be set on creation of a new a volume. It is mandatory to provide either 'public image' or 'imageAlias' in conjunction with this property. |
+  | user_data | False | str |  | The cloud-init configuration for the volume as base64 encoded string. The property is immutable and is only allowed to be set on creation of a new a volume. It is mandatory to provide either 'public image' or 'imageAlias' that has cloud-init compatibility in conjunction with this property. |
+  | cpu_hot_plug | False | bool |  | Hot-plug capable CPU (no reboot required). |
+  | ram_hot_plug | False | bool |  | Hot-plug capable RAM (no reboot required) |
+  | nic_hot_plug | False | bool |  | Hot-plug capable NIC (no reboot required). |
+  | nic_hot_unplug | False | bool |  | Hot-unplug capable NIC (no reboot required) |
+  | disc_virtio_hot_plug | False | bool |  | Hot-plug capable Virt-IO drive (no reboot required). |
+  | disc_virtio_hot_unplug | False | bool |  | Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove Volumes
+  - volume:
+    datacenter: Tardis One
+    instance_ids:
+      - 'vol01'
+      - 'vol02'
+    wait_timeout: 500
+    state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter in which to create the volumes. |
+  | name | False | str |  | The name of the volumes. You can enumerate the names using auto_increment. |
+  | instance_ids | False | list |  | list of instance ids, currently only used when state='absent' to remove instances. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update Volumes
+  - volume:
+      datacenter: Tardis One
+      instance_ids:
+        - 'vol01'
+        - 'vol02'
+      size: 50
+      bus: IDE
+      wait_timeout: 500
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | datacenter | True | str |  | The datacenter in which to create the volumes. |
+  | name | False | str |  | The name of the volumes. You can enumerate the names using auto_increment. |
+  | size | False | int | 10 | The size of the volume. |
+  | bus | False | str | VIRTIO | The bus type. |
+  | availability_zone | False | str |  | The storage availability zone assigned to the volume. |
+  | instance_ids | False | list |  | list of instance ids, currently only used when state='absent' to remove instances. |
+  | cpu_hot_plug | False | bool |  | Hot-plug capable CPU (no reboot required). |
+  | ram_hot_plug | False | bool |  | Hot-plug capable RAM (no reboot required) |
+  | nic_hot_plug | False | bool |  | Hot-plug capable NIC (no reboot required). |
+  | nic_hot_unplug | False | bool |  | Hot-unplug capable NIC (no reboot required) |
+  | disc_virtio_hot_plug | False | bool |  | Hot-plug capable Virt-IO drive (no reboot required). |
+  | disc_virtio_hot_unplug | False | bool |  | Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/dbaas-postgres/postgres_backup_info.md
+++ b/docs/api/dbaas-postgres/postgres_backup_info.md
@@ -1,8 +1,12 @@
-# Postgres Backup Info
+# postgres_backup_info
+
+This is a simple module that supports listing existing Postgres Cluster backups
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
   - name: List Postgres Cluster Backups
     postgres_cluster_info:
       postgres_cluster: {{ postgres_cluster.id }}
@@ -12,14 +16,25 @@
     debug:
       var: postgres_clusters_response.result
 ```
+=======
+>>>>>>> 00db8fa... feat: generate docs (#61)
 
-## Parameter Reference
+    - name: List Postgres Cluster Backups
+        postgres_cluster_info:
+            postgres_cluster: {{ postgres_cluster.id }}
+        register: postgres_clusters_response
 
-The following parameters are supported:
+    - name: Show Postgres Cluster Backups
+        debug:
+            var: postgres_clusters_response.result
+
+```
+### Available parameters:
+&nbsp;
 
 | Name | Required | Type | Default | Description |
 | :--- | :---: | :--- | :--- | :--- |
-| postgres_cluster | no | string |  | Either a UUID or a display name of the Postgres cluster. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
+| postgres_cluster | True | str |  | The ID or name of an existing Postgres Cluster. |
+| api_url | True | str |  | The Ionos API base URL. |
+| username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |

--- a/docs/api/dbaas-postgres/postgres_cluster.md
+++ b/docs/api/dbaas-postgres/postgres_cluster.md
@@ -1,7 +1,63 @@
-# Postgres Cluster
+# postgres_cluster
+
+This is a module that supports creating, updating, restoring or destroying Postgres Clusters
 
 ## Example Syntax
 
+
+```yaml
+<<<<<<< HEAD
+  - name: Create Postgres Cluster
+=======
+- name: Create Postgres Cluster
+>>>>>>> 00db8fa... feat: generate docs (#61)
+    postgres_cluster:
+      postgres_version: 12
+      instances: 1
+      cores: 1
+      ram: 2048
+      storage_size: 20480
+      storage_type: HDD
+      location: de/fra
+      connections:
+        - cidr: 192.168.1.106/24
+          datacenter: "{{ datacenter_response.datacenter.id }}"
+          lan: "{{ lan_response1.lan.id }}"
+      display_name: backuptest-04
+      synchronization_mode: ASYNCHRONOUS
+      db_username: test
+      db_password: 7357cluster
+      wait: true
+    register: cluster_response
+<<<<<<< HEAD
+
+  - name: Update Postgres Cluster
+=======
+  
+- name: Update Postgres Cluster
+>>>>>>> 00db8fa... feat: generate docs (#61)
+    postgres_cluster:
+      postgres_cluster: "{{ cluster_response.postgres_cluster.id }}"
+      postgres_version: 12
+      instances: 2
+      cores: 2
+      ram: 4096
+      storage_size: 30480
+      state: update
+      wait: true
+    register: updated_cluster_response
+  
+- name: Delete Postgres Cluster
+    postgres_cluster:
+      postgres_cluster: "{{ cluster_response.postgres_cluster.id }}"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
 ```yaml
   - name: Create Postgres Cluster
     postgres_cluster:
@@ -22,7 +78,64 @@
       db_password: 7357cluster
       wait: true
     register: cluster_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | maintenance_window | False | dict |  | Dict containing &quot;time&quot; (the time of the day when to perform the maintenance) and &quot;day_of_the_week&quot; (the Day Of the week when to perform the maintenance). |
+  | postgres_version | True | str |  | The PostgreSQL version of your cluster |
+  | instances | True | int |  | The total number of instances in the cluster (one master and n-1 standbys). |
+  | cores | True | int |  | The number of CPU cores per instance. |
+  | ram | True | int |  | The amount of memory per instance(should be a multiple of 1024). |
+  | storage_size | True | int |  | The amount of storage per instance. |
+  | storage_type | True | str |  | The storage type used in your cluster. |
+  | connections | True | list |  | Array of VDCs to connect to your cluster. |
+  | location | True | str |  | The physical location where the cluster will be created. This will be where all of your instances live. Property cannot be modified after datacenter creation (disallowed in update requests) |
+  | display_name | True | str |  | The friendly name of your cluster. |
+  | db_username | True | str |  | The username for the initial postgres user. Some system usernames are restricted (e.g. &quot;postgres&quot;, &quot;admin&quot;, &quot;standby&quot;) |
+  | db_password | True | str |  | The username for the initial postgres user. |
+  | synchronization_mode | True | str |  | Represents different modes of replication. |
+  | backup_id | False | str |  | The ID of the backup to be used. |
+  | recovery_target_time | False | str |  | Recovery target time. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  - name: Delete Postgres Cluster
+    postgres_cluster:
+      postgres_cluster: "{{ cluster_response.postgres_cluster.id }}"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | postgres_cluster | True | str |  | The ID or name of an existing Postgres Cluster. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
   - name: Update Postgres Cluster
     postgres_cluster:
       postgres_cluster: "{{ cluster_response.postgres_cluster.id }}"
@@ -34,38 +147,50 @@
       state: update
       wait: true
     register: updated_cluster_response
-
-  - name: Delete Postgres Cluster
-    postgres_cluster:
-      postgres_cluster: "{{ cluster_response.postgres_cluster.id }}"
-      state: absent
+  
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | maintenance_window | False | dict |  | Dict containing &quot;time&quot; (the time of the day when to perform the maintenance) and &quot;day_of_the_week&quot; (the Day Of the week when to perform the maintenance). |
+  | postgres_version | False | str |  | The PostgreSQL version of your cluster |
+  | instances | False | int |  | The total number of instances in the cluster (one master and n-1 standbys). |
+  | cores | False | int |  | The number of CPU cores per instance. |
+  | ram | False | int |  | The amount of memory per instance(should be a multiple of 1024). |
+  | storage_size | False | int |  | The amount of storage per instance. |
+  | display_name | False | str |  | The friendly name of your cluster. |
+  | postgres_cluster | True | str |  | The ID or name of an existing Postgres Cluster. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| postgres_version | **yes**/no | string |  | The PostgreSQL version of your cluster. Required only for state = 'present' |
-| instances | **yes**/no | string |  | The total number of instances in the cluster (one master and n-1 standbys). Required only for state = 'present' |
-| cores | **yes**/no | string |  | The number of CPU cores per instance. Required only for state = 'present' |
-| ram | **yes**/no | string |  | The amount of memory per instance(should be a multiple of 1024). Required only for state = 'present' |
-| storage_size | **yes**/no | string |  | The amount of storage per instance. Required only for state = 'present' |
-| storage_type | **yes**/no | string |  | The storage type used in your cluster. Required only for state = 'present' |
-| connections | **yes**/no | string |  | Array of VDCs to connect to your cluster. A VDC is described as a dict containing 'datacenter', 'lan' and 'cidr'. For datacenter and lan either name or UUID may be specified. Required only for state = 'present' |
-| location | **yes**/no | string |  | The physical location where the cluster will be created. This will be where all of your instances live. (disallowed in update requests). Required only for state = 'present' |
-| display_name | **yes**/no | string |  | The friendly name of your cluster. Required only for state = 'present' |
-| db_username | **yes**/no | string |  | The username for the initial postgres user. Some system usernames are restricted (e.g. "postgres", "admin", standby"). Required only for state = 'present' |
-| db_password | **yes**/no | string |  | The password for the initial postgres user. Required only for state = 'present' |
-| synchronization_mode | **yes**/no | string |  | Represents different modes of replication. Required only for state = 'present' |
-| backup_id | no | string |  | The unique ID of the backup you want to restore. |
-| recovery_target_time | no | string |  | If this value is supplied as ISO 8601 timestamp, the backup will be replayed up until the given timestamp. If empty, the backup will be applied completely. |
-| maintenance\_window | no | dict |  | The day and time for the maintenance. Contains 'dayOfTheWeek' and 'time'. |
-| postgres_cluster | **yes**/no | string |  | Either a UUID or a display name of the Postgres cluster. Required only for state = 'absent', state = 'update' or state = 'restore' |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update or restore |
+&nbsp;
+# state: **restore**
+```yaml
+  
+```
+### Available parameters for state **restore**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | backup_id | True | str |  | The ID of the backup to be used. |
+  | recovery_target_time | False | str |  | Recovery target time. |
+  | postgres_cluster | True | str |  | The ID or name of an existing Postgres Cluster. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/dbaas-postgres/postgres_cluster_info.md
+++ b/docs/api/dbaas-postgres/postgres_cluster_info.md
@@ -1,24 +1,33 @@
-# Postgres Cluster Info
+# postgres_cluster_info
+
+This is a simple module that supports listing existing Postgres Clusters
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
   - name: List Postgres Clusters
       postgres_cluster_info:
       register: postgres_clusters_response
+=======
+>>>>>>> 00db8fa... feat: generate docs (#61)
+
+    - name: List Postgres Clusters
+        postgres_cluster_info:
+        register: postgres_clusters_response
 
 
-  - name: Show Postgres Clusters
-      debug:
-          var: postgres_clusters_response.result
+    - name: Show Postgres Clusters
+        debug:
+            var: postgres_clusters_response.result
+
 ```
-
-## Parameter Reference
-
-The following parameters are supported:
+### Available parameters:
+&nbsp;
 
 | Name | Required | Type | Default | Description |
 | :--- | :---: | :--- | :--- | :--- |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
+| api_url | True | str |  | The Ionos API base URL. |
+| username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |

--- a/docs/api/managed-kubernetes/k8s_cluster.md
+++ b/docs/api/managed-kubernetes/k8s_cluster.md
@@ -1,30 +1,30 @@
-# backupunit
+# k8s_cluster
 
-This is a simple module that supports creating or removing Backup Units. This module has a dependency on ionos-cloud &gt;= 6.0.0
+This is a simple module that supports creating or removing K8s Clusters. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
 
 ```yaml
-# Create a Backup Unit
-  - name: Create Backup Unit
-    backupunit:
-      backupunit_email: "{{ email }}"
-      backupunit_password: "{{ password }}"
-      name: "{{ name }}"
+
+  - name: Create k8s cluster
+    k8s_cluster:
+      name: "{{ cluster_name }}"
   
-# Update a Backup Unit
-  - name: Update a Backup Unit
-    backupunit:
-      backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
-      backupunit_email: "{{ updated_email }}"
-      backupunit_password:  "{{ updated_password }}"
+
+  - name: Update k8s cluster
+    k8s_cluster:
+      k8s_cluster_id: "89a5aeb0-d6c1-4cef-8f6b-2b9866d85850"
+      maintenance_window:
+        day_of_the_week: 'Tuesday'
+        time: '13:03:00'
+      k8s_version: 1.17.8
       state: update
   
-# Destroy a Backup Unit.
-  - name: Remove Backup Unit
-    backupunit:
-      backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
+
+  - name: Delete k8s cluster
+    k8s_cluster:
+      k8s_cluster_id: "a9b56a4b-8033-4f1a-a59d-cfea86cfe40b"
       state: absent
   
 ```
@@ -34,42 +34,23 @@ This is a simple module that supports creating or removing Backup Units. This mo
 
 # state: **present**
 ```yaml
-<<<<<<< HEAD
-    - name: Create backupunit
-      backupunit:
-        backupunit_email: "{{ email }}"
-        backupunit_password: "{{ password }}"
-        name: "{{ name }}"
-
-    - name: Update a backupunit
-      backupunit:
-        backupunit_id: "{{backupunit.id}}"
-        backupunit_email: "{{ updated_email }}"
-        backupunit_password:  "{{ updated_password }}"
-        state: update
-
-    - name: Remove backupunit
-      backupunit:
-        backupunit_id: "{{backupunit.id}}"
-        state: absent
-=======
-  # Create a Backup Unit
-  - name: Create Backup Unit
-    backupunit:
-      backupunit_email: "{{ email }}"
-      backupunit_password: "{{ password }}"
-      name: "{{ name }}"
   
->>>>>>> 00db8fa... feat: generate docs (#61)
+  - name: Create k8s cluster
+    k8s_cluster:
+      name: "{{ cluster_name }}"
+  
 ```
 ### Available parameters for state **present**:
 &nbsp;
 
   | Name | Required | Type | Default | Description |
   | :--- | :---: | :--- | :--- | :--- |
-  | name | True | str |  | The name of the virtual Backup Unit. |
-  | backupunit_password | False | str |  | The password of the Backup Unit. |
-  | backupunit_email | True | str |  | The email of the Backup Unit. |
+  | cluster_name | True | str |  | The name of the K8s cluster. |
+  | k8s_version | False | str |  | The description of the virtual datacenter. |
+  | maintenance_window | False | dict |  | The datacenter location. |
+  | public | False | bool |  | The datacenter location. |
+  | api_subnet_allow_list | False | list |  | The datacenter location. |
+  | s3_buckets_param | False | list |  | The datacenter location. |
   | api_url | False | str |  | The Ionos API base URL. |
   | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
   | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
@@ -82,10 +63,10 @@ This is a simple module that supports creating or removing Backup Units. This mo
 &nbsp;
 # state: **absent**
 ```yaml
-  # Destroy a Backup Unit.
-  - name: Remove Backup Unit
-    backupunit:
-      backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
+  
+  - name: Delete k8s cluster
+    k8s_cluster:
+      k8s_cluster_id: "a9b56a4b-8033-4f1a-a59d-cfea86cfe40b"
       state: absent
   
 ```
@@ -94,8 +75,7 @@ This is a simple module that supports creating or removing Backup Units. This mo
 
   | Name | Required | Type | Default | Description |
   | :--- | :---: | :--- | :--- | :--- |
-  | name | False | str |  | The name of the virtual Backup Unit. |
-  | backupunit_id | True | str |  | The ID of the virtual Backup Unit. |
+  | k8s_cluster_id | True | str |  | The ID of the K8s cluster. |
   | api_url | False | str |  | The Ionos API base URL. |
   | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
   | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
@@ -108,12 +88,14 @@ This is a simple module that supports creating or removing Backup Units. This mo
 &nbsp;
 # state: **update**
 ```yaml
-  # Update a Backup Unit
-  - name: Update a Backup Unit
-    backupunit:
-      backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
-      backupunit_email: "{{ updated_email }}"
-      backupunit_password:  "{{ updated_password }}"
+  
+  - name: Update k8s cluster
+    k8s_cluster:
+      k8s_cluster_id: "89a5aeb0-d6c1-4cef-8f6b-2b9866d85850"
+      maintenance_window:
+        day_of_the_week: 'Tuesday'
+        time: '13:03:00'
+      k8s_version: 1.17.8
       state: update
   
 ```
@@ -122,8 +104,12 @@ This is a simple module that supports creating or removing Backup Units. This mo
 
   | Name | Required | Type | Default | Description |
   | :--- | :---: | :--- | :--- | :--- |
-  | name | False | str |  | The name of the virtual Backup Unit. |
-  | backupunit_id | True | str |  | The ID of the virtual Backup Unit. |
+  | cluster_name | True | str |  | The name of the K8s cluster. |
+  | k8s_cluster_id | True | str |  | The ID of the K8s cluster. |
+  | k8s_version | True | str |  | The description of the virtual datacenter. |
+  | maintenance_window | True | dict |  | The datacenter location. |
+  | api_subnet_allow_list | False | list |  | The datacenter location. |
+  | s3_buckets_param | False | list |  | The datacenter location. |
   | api_url | False | str |  | The Ionos API base URL. |
   | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
   | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |

--- a/docs/api/managed-kubernetes/k8s_config.md
+++ b/docs/api/managed-kubernetes/k8s_config.md
@@ -1,0 +1,45 @@
+# k8s_config
+
+This is a simple module that supports getting config of K8s clusters This module has a dependency on ionos-cloud &gt;= 6.0.0
+
+## Example Syntax
+
+
+```yaml
+
+  - name: Get k8s config
+  k8s_config:
+    k8s_cluster_id: "ed67d8b3-63c2-4abe-9bf0-073cee7739c9"
+    config_file: 'config.yaml'
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Get k8s config
+  k8s_config:
+    k8s_cluster_id: "ed67d8b3-63c2-4abe-9bf0-073cee7739c9"
+    config_file: 'config.yaml'
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | k8s_cluster_id | True | str |  | The ID of the K8s cluster. |
+  | config_file | True | str |  | The name of the file in which to save the config. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/managed-kubernetes/k8s_nodepool.md
+++ b/docs/api/managed-kubernetes/k8s_nodepool.md
@@ -1,0 +1,171 @@
+# k8s_nodepool
+
+This is a simple module that supports creating or removing K8s Nodepools. This module has a dependency on ionos-cloud &gt;= 6.0.0
+
+## Example Syntax
+
+
+```yaml
+
+  - name: Create k8s cluster nodepool
+    k8s_nodepools:
+      cluster_name: "{{ name }}"
+      k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
+      datacenter_id: "4d495548-e330-434d-83a9-251bfa645875"
+      node_count: "1"
+      cpu_family: "AMD_OPTERON"
+      cores_count: "1"
+      ram_size: "2048"
+      availability_zone: "AUTO"
+      storage_type: "SSD"
+      storage_size: "100"
+  
+
+  - name: Update k8s cluster nodepool
+    k8s_nodepools:
+      cluster_name: "{{ name }}"
+      k8s_cluster_id: "ed67d8b3-63c2-4abe-9bf0-073cee7739c9"
+      nodepool_id: "6e9efcc6-649a-4514-bee5-6165b614c89e"
+      node_count: 1
+      cores_count: "1"
+      maintenance_window:
+        day_of_the_week: 'Tuesday'
+        time: '13:03:00'
+      auto_scaling:
+        min_node_count: 1
+        max_node_count: 3
+      state: update
+  
+
+  - name: Delete k8s cluster nodepool
+    k8s_nodepools:
+      k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
+      nodepool_id: "e3aa6101-436f-49fa-9a8c-0d6617e0a277"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Create k8s cluster nodepool
+    k8s_nodepools:
+      cluster_name: "{{ name }}"
+      k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
+      datacenter_id: "4d495548-e330-434d-83a9-251bfa645875"
+      node_count: "1"
+      cpu_family: "AMD_OPTERON"
+      cores_count: "1"
+      ram_size: "2048"
+      availability_zone: "AUTO"
+      storage_type: "SSD"
+      storage_size: "100"
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | nodepool_name | True | str |  | The name of the K8s Nodepool. |
+  | k8s_cluster_id | True | str |  | The ID of the K8s cluster. |
+  | k8s_version | False | str |  | The Kubernetes version the nodepool is running. |
+  | datacenter_id | True | str |  | A valid ID of the data center, to which the user has access. |
+  | lan_ids | False | list |  | Array of additional LANs attached to worker nodes. |
+  | node_count | False | int |  | The number of nodes that make up the node pool. |
+  | cpu_family | True | str |  | A valid CPU family name. |
+  | cores_count | True | str |  | The number of cores for the node. |
+  | ram_size | True | str |  | The RAM size for the node. Must be set in multiples of 1024 MB, with minimum size is of 2048 MB. |
+  | availability_zone | True | str |  | The availability zone in which the target VM should be provisioned. |
+  | storage_type | True | str |  | The type of hardware for the volume. |
+  | storage_size | True | str |  | The size of the volume in GB. The size should be greater than 10GB. |
+  | maintenance_window | False | dict |  | The maintenance window is used for updating the software on the nodepool's nodes and for upgrading the nodepool's K8s version. If no value is given, one is chosen dynamically, so there is no fixed default. |
+  | labels | False | dict |  | Map of labels attached to node pool. |
+  | annotations | False | dict |  | Map of annotations attached to node pool. |
+  | auto_scaling | False | dict |  | Property to be set when auto-scaling needs to be enabled for the nodepool. By default, auto-scaling is not enabled. |
+  | public_ips | False | list |  | Optional array of reserved public IP addresses to be used by the nodes. IPs must be from same location as the data center used for the node pool. The array must contain one more IP than maximum number possible number of nodes (nodeCount+1 for fixed number of nodes or maxNodeCount+1 when auto scaling is used). The extra IP is used when the nodes are rebuilt. |
+  | gateway_ip | False | str |  | Public IP address for the gateway performing source NAT for the node pool's nodes belonging to a private cluster. Required only if the node pool belongs to a private cluster. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Delete k8s cluster nodepool
+    k8s_nodepools:
+      k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
+      nodepool_id: "e3aa6101-436f-49fa-9a8c-0d6617e0a277"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | k8s_cluster_id | True | str |  | The ID of the K8s cluster. |
+  | nodepool_id | True | str |  | The ID of the K8s nodepool. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  
+  - name: Update k8s cluster nodepool
+    k8s_nodepools:
+      cluster_name: "{{ name }}"
+      k8s_cluster_id: "ed67d8b3-63c2-4abe-9bf0-073cee7739c9"
+      nodepool_id: "6e9efcc6-649a-4514-bee5-6165b614c89e"
+      node_count: 1
+      cores_count: "1"
+      maintenance_window:
+        day_of_the_week: 'Tuesday'
+        time: '13:03:00'
+      auto_scaling:
+        min_node_count: 1
+        max_node_count: 3
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | nodepool_name | False | str |  | The name of the K8s Nodepool. |
+  | k8s_cluster_id | True | str |  | The ID of the K8s cluster. |
+  | k8s_version | False | str |  | The Kubernetes version the nodepool is running. |
+  | nodepool_id | True | str |  | The ID of the K8s nodepool. |
+  | datacenter_id | False | str |  | A valid ID of the data center, to which the user has access. |
+  | lan_ids | False | list |  | Array of additional LANs attached to worker nodes. |
+  | node_count | False | int |  | The number of nodes that make up the node pool. |
+  | maintenance_window | False | dict |  | The maintenance window is used for updating the software on the nodepool's nodes and for upgrading the nodepool's K8s version. If no value is given, one is chosen dynamically, so there is no fixed default. |
+  | auto_scaling | False | dict |  | Property to be set when auto-scaling needs to be enabled for the nodepool. By default, auto-scaling is not enabled. |
+  | public_ips | False | list |  | Optional array of reserved public IP addresses to be used by the nodes. IPs must be from same location as the data center used for the node pool. The array must contain one more IP than maximum number possible number of nodes (nodeCount+1 for fixed number of nodes or maxNodeCount+1 when auto scaling is used). The extra IP is used when the nodes are rebuilt. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/natgateway/nat_gateway.md
+++ b/docs/api/natgateway/nat_gateway.md
@@ -1,9 +1,13 @@
-# NAT Gateway
+# nat_gateway
+
+This is a simple module that supports creating or removing NATGateways. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
 
+<<<<<<< HEAD
     - name: Create NAT Gateway
       nat_gateway:
         datacenter_id: "{{ datacenter_response.datacenter.id }}"
@@ -33,23 +37,139 @@
        wait_timeout: 2000
        state: absent
     
+=======
+  - name: Create NAT Gateway
+    nat_gateway:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }}"
+      public_ips: "{{ ipblock_response_create.ipblock.properties.ips }}"
+      lans:
+        - id: "{{ lan_response.lan.id }}"
+          gateway_ips: "10.11.2.5/24"
+      wait: true
+    register: nat_gateway_response
+  
+
+  - name: Update NAT Gateway
+    nat_gateway:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }} - UPDATED"
+      public_ips: "{{ ipblock_response_update.ipblock.properties.ips }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      wait: true
+      state: update
+    register: nat_gateway_response_update
+  
+
+  - name: Remove NAT Gateway
+    nat_gateway:
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      wait: true
+      wait_timeout: 2000
+      state: absent
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+&nbsp;
 
-## Parameter Reference
+&nbsp;
 
-The following parameters are supported:
+# state: **present**
+```yaml
+  
+  - name: Create NAT Gateway
+    nat_gateway:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }}"
+      public_ips: "{{ ipblock_response_create.ipblock.properties.ips }}"
+      lans:
+        - id: "{{ lan_response.lan.id }}"
+          gateway_ips: "10.11.2.5/24"
+      wait: true
+    register: nat_gateway_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes** | string |  | The name of the NAT Gateway. |
-| datacenter_id | **yes** | string | | The ID of the datacenter |
-| nat_gateway_id | **yes**/no | string |  | The ID of the NAT Gateway. Required when state = 'update' or state = 'absent'. |
-| lans | no | string |  | Collection of LANs connected to the NAT gateway. IPs must contain valid subnet mask. If user will not provide any IP then system will generate an IP with /24 subnet. |
-| public_ips | **yes**/no | string |  | Collection of public IP addresses of the NAT gateway. Should be customer reserved IP addresses in that location. Required only for state = 'present'. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the NAT Gateway. |
+  | public_ips | True | list |  | Collection of public IP addresses of the NAT Gateway. Should be customer reserved IP addresses in that location. |
+  | lans | False | list |  | Collection of LANs connected to the NAT Gateway. IPs must contain a valid subnet mask. If no IP is provided, the system will generate an IP with /24 subnet. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Remove NAT Gateway
+    nat_gateway:
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      wait: true
+      wait_timeout: 2000
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the NAT Gateway. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | False | str |  | The ID of the NAT Gateway. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  
+  - name: Update NAT Gateway
+    nat_gateway:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }} - UPDATED"
+      public_ips: "{{ ipblock_response_update.ipblock.properties.ips }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      wait: true
+      state: update
+    register: nat_gateway_response_update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the NAT Gateway. |
+  | public_ips | False | list |  | Collection of public IP addresses of the NAT Gateway. Should be customer reserved IP addresses in that location. |
+  | lans | False | list |  | Collection of LANs connected to the NAT Gateway. IPs must contain a valid subnet mask. If no IP is provided, the system will generate an IP with /24 subnet. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | False | str |  | The ID of the NAT Gateway. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/natgateway/nat_gateway_flowlog.md
+++ b/docs/api/natgateway/nat_gateway_flowlog.md
@@ -1,8 +1,119 @@
-# NAT Gateway Flowlog
+# nat_gateway_flowlog
+
+This is a simple module that supports creating or removing NATGateway Flowlogs. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      name: "{{ name }}"
+      action: "ACCEPTED"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      wait: true
+    register: nat_gateway_flowlog_response
+  
+
+  - name: Update NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
+      name: "{{ name }}"
+      action: "ALL"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      wait: true
+      state: update
+    register: nat_gateway_flowlog_update_response
+  
+
+  - name: Delete NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Create NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      name: "{{ name }}"
+      action: "ACCEPTED"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      wait: true
+    register: nat_gateway_flowlog_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the flowlog. |
+  | action | True | str |  | Specifies the traffic action pattern. |
+  | direction | True | str |  | Specifies the traffic direction pattern. |
+  | bucket | True | str |  | S3 bucket name of an existing IONOS Cloud S3 bucket. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | True | str |  | The ID of the NAT Gateway. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Delete NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the flowlog. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | True | str |  | The ID of the NAT Gateway. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+<<<<<<< HEAD
     - name: Create NAT Gateway Flowlog
       nat_gateway_flowlog:
         name: "{{ name }}"
@@ -34,26 +145,42 @@
         flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
         state: absent
     
+=======
+  
+  - name: Update NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
+      name: "{{ name }}"
+      action: "ALL"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      wait: true
+      state: update
+    register: nat_gateway_flowlog_update_response
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the flowlog. |
+  | action | False | str |  | Specifies the traffic action pattern. |
+  | direction | False | str |  | Specifies the traffic direction pattern. |
+  | bucket | False | str |  | S3 bucket name of an existing IONOS Cloud S3 bucket. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | True | str |  | The ID of the NAT Gateway. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes**/no | string |  | The name of the Flowlog. Required only for state = 'present'. |
-| action | **yes**/no | string |  | Specifies the traffic action pattern. Accepted values: "ACCEPTED", "REJECTED" or "ALL". Required only for state = 'present'.|
-| direction | **yes**/no | string |  | Specifies the traffic direction pattern. Accepted values: "INGRESS", "EGRESS", "BIDIRECTIONAL". Required only for state = 'present'. |
-| bucket | **yes**/no | string |  | S3 bucket name of an existing IONOS Cloud S3 bucket. Required only for state = 'present'. |
-| datacenter_id | **yes** | string |  | The ID of the datacenter. |
-| server_id | **yes** | string |  | The ID of the server. |
-| flowlog_id | **yes**/no | string |  | The ID of the flowlog. Required when state = 'update' or state = 'absent'.|
-| nat_gateway_id | **yes** | string |  | The ID of the NAT Gateway. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
-
+&nbsp;

--- a/docs/api/natgateway/nat_gateway_rule.md
+++ b/docs/api/natgateway/nat_gateway_rule.md
@@ -1,8 +1,133 @@
-# NAT Gateway Rule
+# nat_gateway_rule
+
+This is a simple module that supports creating or removing NATGateway rules. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      name: "{{ name }}"
+      type: "SNAT"
+      protocol: "TCP"
+      source_subnet: "10.0.1.0/24"
+      target_subnet: "10.0.1.0"
+      target_port_range:
+        start: 10000
+        end: 20000
+      public_ip: "{{ ipblock_response.ipblock.properties.ips[0] }}"
+      wait: true
+    register: nat_gateway_rule_response
+  
+
+  - name: Update NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
+      public_ip: "{{ ipblock_response.ipblock.properties.ips[1] }}"
+      name: "{{ name }} - UPDATED"
+      type: "SNAT"
+      protocol: "TCP"
+      source_subnet: "10.0.1.0/24"
+      wait: true
+      state: update
+    register: nat_gateway_rule_update_response
+  
+
+  - name: Delete NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Create NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      name: "{{ name }}"
+      type: "SNAT"
+      protocol: "TCP"
+      source_subnet: "10.0.1.0/24"
+      target_subnet: "10.0.1.0"
+      target_port_range:
+        start: 10000
+        end: 20000
+      public_ip: "{{ ipblock_response.ipblock.properties.ips[0] }}"
+      wait: true
+    register: nat_gateway_rule_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the NAT Gateway rule. |
+  | type | True | str |  | Type of the NAT Gateway rule. |
+  | protocol | False | str |  | Protocol of the NAT Gateway rule. Defaults to ALL. If protocol is 'ICMP' then targetPortRange start and end cannot be set. |
+  | source_subnet | True | str |  | Source subnet of the NAT Gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on the packets source IP address. |
+  | public_ip | True | str |  | Public IP address of the NAT Gateway rule. Specifies the address used for masking outgoing packets source address field. Should be one of the customer reserved IP address already configured on the NAT Gateway resource. |
+  | target_subnet | False | str |  | Target or destination subnet of the NAT Gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on the packets destination IP address. If none is provided, rule will match any address. |
+  | target_port_range | False | str |  | Target port range of the NAT Gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on destination port. If none is provided, rule will match any port. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | True | str |  | The ID of the NAT Gateway. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Delete NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the NAT Gateway rule. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | True | str |  | The ID of the NAT Gateway. |
+  | nat_gateway_rule_id | False | str |  | The ID of the NAT Gateway rule. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+<<<<<<< HEAD
     - name: Create NAT Gateway Rule
       nat_gateway_rule:
         datacenter_id: "{{ datacenter_response.datacenter.id }}"
@@ -40,28 +165,46 @@
         nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
         state: absent
     
+=======
+  
+  - name: Update NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
+      public_ip: "{{ ipblock_response.ipblock.properties.ips[1] }}"
+      name: "{{ name }} - UPDATED"
+      type: "SNAT"
+      protocol: "TCP"
+      source_subnet: "10.0.1.0/24"
+      wait: true
+      state: update
+    register: nat_gateway_rule_update_response
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the NAT Gateway rule. |
+  | type | False | str |  | Type of the NAT Gateway rule. |
+  | protocol | False | str |  | Protocol of the NAT Gateway rule. Defaults to ALL. If protocol is 'ICMP' then targetPortRange start and end cannot be set. |
+  | source_subnet | False | str |  | Source subnet of the NAT Gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on the packets source IP address. |
+  | public_ip | False | str |  | Public IP address of the NAT Gateway rule. Specifies the address used for masking outgoing packets source address field. Should be one of the customer reserved IP address already configured on the NAT Gateway resource. |
+  | target_subnet | False | str |  | Target or destination subnet of the NAT Gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on the packets destination IP address. If none is provided, rule will match any address. |
+  | target_port_range | False | str |  | Target port range of the NAT Gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on destination port. If none is provided, rule will match any port. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | nat_gateway_id | True | str |  | The ID of the NAT Gateway. |
+  | nat_gateway_rule_id | False | str |  | The ID of the NAT Gateway rule. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes**/no | string |  | The name of the NAT gateway rule. Required only for state = 'present'.|
-| type | no | string |  | The type of the NAT gateway rule. Accepted values: "SNAT". |
-| protocol | no | string |  | Protocol of the NAT gateway rule. Defaults to ALL. If protocol is 'ICMP' then targetPortRange start and end cannot be set. Accepted values: "TCP", "UDP","ICMP", "ALL". |
-| source_subnet | **yes**/no | string |  | Source subnet of the NAT gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on the packets source IP address. Required only for state = 'present'. |
-| public_ip | **yes**/no | string |  | Public IP address of the NAT gateway rule. Specifies the address used for masking outgoing packets source address field. Should be one of the customer reserved IP address already configured on the NAT gateway resource. Required only for state = 'present'. |
-| target_subnet | no | string |  | Target or destination subnet of the NAT gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on the packets destination IP address. If none is provided, rule will match any address. |
-| target_port_range | no | Dict containing: 'start' and 'end'. |  | Target port range of the NAT gateway rule. For SNAT rules it specifies which packets this translation rule applies to based on destination port. If none is provided, rule will match any port|
-| datacenter_id | **yes** | string |  | The ID of the datacenter. |
-| nat_gateway_id | **yes** | string |  | The ID of the NAT Gateway. |
-| nat_gateway_rule_id | **yes**/no | string |  | The ID of the NAT Gateway Rule. Required when state = 'update' or state = 'absent'.|
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
-
+&nbsp;

--- a/docs/api/networkloadbalancer/network_load_balancer.md
+++ b/docs/api/networkloadbalancer/network_load_balancer.md
@@ -1,8 +1,116 @@
-# Network Load Balancer
+# network_load_balancer
+
+This is a simple module that supports creating or removing NetworkLoadbalancers. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create Network Load Balancer
+    network_load_balancer:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }}"
+      ips:
+        - "10.12.118.224"
+      listener_lan: "{{ listener_lan.lan.id }}"
+      target_lan: "{{ target_lan.lan.id }}"
+      wait: true
+    register: nlb_response
+  
+
+  - name: Update Network Load Balancer
+    network_load_balancer:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      name: "{{ name }} - UPDATE"
+      listener_lan: "{{ listener_lan.lan.id }}"
+      target_lan: "{{ target_lan.lan.id }}"
+      wait: true
+      state: update
+    register: nlb_response_update
+  
+
+  - name: Remove Network Load Balancer
+    network_load_balancer:
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      wait: true
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Create Network Load Balancer
+    network_load_balancer:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }}"
+      ips:
+        - "10.12.118.224"
+      listener_lan: "{{ listener_lan.lan.id }}"
+      target_lan: "{{ target_lan.lan.id }}"
+      wait: true
+    register: nlb_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the Network Loadbalancer forwarding rule. |
+  | listener_lan | True | str |  | ID of the listening LAN (inbound). |
+  | ips | False | list |  | Collection of the Network Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan must be customer-reserved IPs for public Load Balancers, and private IPs for private Load Balancers. |
+  | target_lan | True | str |  | ID of the balanced private target LAN (outbound). |
+  | lb_private_ips | False | list |  | Collection of private IP addresses with subnet mask of the Network Load Balancer. IPs must contain a valid subnet mask. If no IP is provided, the system will generate an IP with /24 subnet. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Remove Network Load Balancer
+    network_load_balancer:
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      wait: true
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the Network Loadbalancer forwarding rule. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | False | str |  | The ID of the Network Loadbalancer. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+<<<<<<< HEAD
     - name: Create Network Load Balancer
       network_load_balancer:
         datacenter_id: "{{ datacenter_response.datacenter.id }}"
@@ -32,25 +140,40 @@
        wait: true
        state: absent
     
+=======
+  
+  - name: Update Network Load Balancer
+    network_load_balancer:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      name: "{{ name }} - UPDATE"
+      listener_lan: "{{ listener_lan.lan.id }}"
+      target_lan: "{{ target_lan.lan.id }}"
+      wait: true
+      state: update
+    register: nlb_response_update
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the Network Loadbalancer forwarding rule. |
+  | listener_lan | True | str |  | ID of the listening LAN (inbound). |
+  | ips | False | list |  | Collection of the Network Load Balancer IP addresses. (Inbound and outbound) IPs of the listenerLan must be customer-reserved IPs for public Load Balancers, and private IPs for private Load Balancers. |
+  | target_lan | True | str |  | ID of the balanced private target LAN (outbound). |
+  | lb_private_ips | False | list |  | Collection of private IP addresses with subnet mask of the Network Load Balancer. IPs must contain a valid subnet mask. If no IP is provided, the system will generate an IP with /24 subnet. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | False | str |  | The ID of the Network Loadbalancer. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes**/no | string |  | The name of the Network Load Balancer. Required only for state = 'present'.|
-| listener_lan | **yes**/no | string |  | Id of the listening LAN. (inbound) Required only for state = 'present'. |
-| ips | no | string |  | Collection of IP addresses of the Network Load Balancer. (inbound and outbound) IP of the listenerLan must be a customer reserved IP for the public load balancer and private IP for the private load balancer. |
-| target_lan | **yes**/no | string |  | Id of the balanced private target LAN. (outbound) Required only for state = 'present'. |
-| lb_private_ips | no | string |  | Collection of private IP addresses with subnet mask of the Network Load Balancer. IPs must contain valid subnet mask. If user will not provide any IP then the system will generate one IP with /24 subnet. |
-| datacenter_id | **yes** | string |  | The ID of the datacenter. |
-| network_load_balancer_id | **yes**/no | string |  | The ID of the Network Load Balancer. Required when state = 'update' or state = 'absent'. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
-
+&nbsp;

--- a/docs/api/networkloadbalancer/network_load_balancer_flowlog.md
+++ b/docs/api/networkloadbalancer/network_load_balancer_flowlog.md
@@ -1,8 +1,120 @@
-# Network Load Balancer Flowlog
+# network_load_balancer_flowlog
+
+This is a simple module that supports creating or removing NetworkLoadbalancer Flowlogs. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      name: "{{ name }}"
+      action: "ACCEPTED"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      wait: true
+    register: nlb_flowlog_response
+  
+
+  - name: Update Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
+      name: "{{ name }}"
+      action: "ALL"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      wait: true
+      state: update
+    register: nlb_flowlog_update_response
+  
+
+  - name: Delete Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Create Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      name: "{{ name }}"
+      action: "ACCEPTED"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      wait: true
+    register: nlb_flowlog_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the flowlog. |
+  | action | True | str |  | Specifies the traffic action pattern. |
+  | direction | True | str |  | Specifies the traffic direction pattern. |
+  | bucket | True | str |  | S3 bucket name of an existing IONOS Cloud S3 bucket. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | True | str |  | The ID of the Network Loadbalancer. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Delete Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the flowlog. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | True | str |  | The ID of the Network Loadbalancer. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+<<<<<<< HEAD
     - name: Create Network Load Balancer Flowlog
       network_load_balancer_flowlog:
         name: "{{ name }}"
@@ -33,26 +145,42 @@
         network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
         flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
         state: absent
+=======
+  
+  - name: Update Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
+      name: "{{ name }}"
+      action: "ALL"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      wait: true
+      state: update
+    register: nlb_flowlog_update_response
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the flowlog. |
+  | action | False | str |  | Specifies the traffic action pattern. |
+  | direction | False | str |  | Specifies the traffic direction pattern. |
+  | bucket | False | str |  | S3 bucket name of an existing IONOS Cloud S3 bucket. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | True | str |  | The ID of the Network Loadbalancer. |
+  | flowlog_id | False | str |  | The ID of the Flowlog. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes**/no | string |  | The name of the Flowlog. Required only for state = 'present'. |
-| action | **yes**/no | string |  | Specifies the traffic action pattern. Accepted values: "ACCEPTED", "REJECTED" or "ALL". Required only for state = 'present'.|
-| direction | **yes**/no | string |  | Specifies the traffic direction pattern. Accepted values: "INGRESS", "EGRESS", "BIDIRECTIONAL". Required only for state = 'present'. |
-| bucket | **yes**/no | string |  | S3 bucket name of an existing IONOS Cloud S3 bucket. Required only for state = 'present'. |
-| datacenter_id | **yes** | string |  | The ID of the datacenter. |
-| server_id | **yes** | string |  | The ID of the server. |
-| flowlog_id | **yes**/no | string |  | The ID of the flowlog. Required when state = 'update' or state = 'absent'.|
-| network_load_balancer_id | **yes** | string |  | The ID of the Network Load Balancer. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
-
+&nbsp;

--- a/docs/api/networkloadbalancer/network_load_balancer_rule.md
+++ b/docs/api/networkloadbalancer/network_load_balancer_rule.md
@@ -1,8 +1,131 @@
-# Network Load Balancer Forwarding Rule
+# network_load_balancer_rule
+
+This is a simple module that supports creating or removing NATGateway Flowlog rules. This module has a dependency on ionos-cloud &gt;= 6.0.0
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      name: "{{ name }}"
+      algorithm: "ROUND_ROBIN"
+      protocol: "TCP"
+      listener_ip: "10.12.118.224"
+      listener_port: "8081"
+      targets:
+        - ip: "22.231.2.2"
+          port: "8080"
+          weight: "123"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      wait: true
+    register: nlb_forwarding_rule_response
+  
+
+  - name: Update Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
+      name: "{{ name }} - UPDATED"
+      algorithm: "ROUND_ROBIN"
+      protocol: "TCP"
+      wait: true
+      state: update
+    register: nlb_forwarding_rule_update_response
+  
+
+  - name: Delete Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+  
+  - name: Create Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      name: "{{ name }}"
+      algorithm: "ROUND_ROBIN"
+      protocol: "TCP"
+      listener_ip: "10.12.118.224"
+      listener_port: "8081"
+      targets:
+        - ip: "22.231.2.2"
+          port: "8080"
+          weight: "123"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      wait: true
+    register: nlb_forwarding_rule_response
+  
+```
+### Available parameters for state **present**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the Network Loadbalancer forwarding rule. |
+  | algorithm | True | str |  | Balancing algorithm. |
+  | protocol | True | str |  | Balancing protocol. |
+  | listener_ip | True | str |  | Listening (inbound) IP. |
+  | listener_port | True | str |  | Listening (inbound) port number; valid range is 1 to 65535. |
+  | health_check | True | dict |  | Health check properties for Network Load Balancer forwarding rule. |
+  | targets | True | list |  | Array of targets. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | True | str |  | The ID of the Network Loadbalancer. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Delete Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the Network Loadbalancer forwarding rule. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | True | str |  | The ID of the Network Loadbalancer. |
+  | forwarding_rule_id | False | str |  | The ID of the Network Loadbalancer forwarding rule. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+<<<<<<< HEAD
     - name: Create Network Load Balancer Forwarding Rule
       network_load_balancer_rule:
         name: "{{ name }}"
@@ -38,28 +161,44 @@
         forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
         state: absent
     
+=======
+  
+  - name: Update Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
+      name: "{{ name }} - UPDATED"
+      algorithm: "ROUND_ROBIN"
+      protocol: "TCP"
+      wait: true
+      state: update
+    register: nlb_forwarding_rule_update_response
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **update**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | False | str |  | The name of the Network Loadbalancer forwarding rule. |
+  | algorithm | False | str |  | Balancing algorithm. |
+  | protocol | False | str |  | Balancing protocol. |
+  | listener_ip | False | str |  | Listening (inbound) IP. |
+  | listener_port | False | str |  | Listening (inbound) port number; valid range is 1 to 65535. |
+  | health_check | False | dict |  | Health check properties for Network Load Balancer forwarding rule. |
+  | targets | False | list |  | Array of targets. |
+  | datacenter_id | True | str |  | The ID of the datacenter. |
+  | network_load_balancer_id | True | str |  | The ID of the Network Loadbalancer. |
+  | forwarding_rule_id | False | str |  | The ID of the Network Loadbalancer forwarding rule. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes**/no | string |  | The name of the Network Load Balancer forwarding rule. Required only for state = 'present'. |
-| algorithm | **yes**/no  | string |  | Algorithm for the balancing. Accepted values: "ROUND_ROBIN", "LEAST_CONNECTION", "RANDOM", "SOURCE_IP". Required only for state = 'present'. |
-| protocol |  **yes**/no | string |  | Protocol of the balancing. Accepted value: "TCP". Required only for state = 'present'. |
-| listener_ip |  **yes**/no | string |  | Listening IP. (inbound) Required only for state = 'present'.|
-| listener_port | **yes**/no  | string |  | Listening port number. (inbound) (range: 1 to 65535). Required only for state = 'present'. |
-| health_check | no | Dict containing: client_timeout, check_timeout, connect_timeout, target_timeout, retries. |  | Health check attributes for Network Load Balancer forwarding rule. |
-| targets |  **yes**/no | Dict containing: ip, port, weight, health_check. | | The list of targets. Required only for state = 'present'. |
-| datacenter_id | **yes**| string |  | The ID of the datacenter. |
-| forwarding_rule_id |**yes**/no | string |  | The ID of the Forwarding Rule. Required when state = 'update' or state = 'absent'. |
-| network_load_balancer_id | **yes**| string |  | The ID of the Network Load Balancer. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
-
+&nbsp;

--- a/docs/api/user-management/group.md
+++ b/docs/api/user-management/group.md
@@ -1,8 +1,12 @@
-# Group
+# group
+
+This module allows you to create, update or remove a group.
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
     - name: Create group
       group:
         name: guests
@@ -18,29 +22,143 @@
         users:
           - john.smith@test.com
         state: update
+=======
+# Create a group
+  - name: Create group
+    group:
+      name: guests
+      create_datacenter: true
+      create_snapshot: true
+      reserve_ip: false
+      access_activity_log: false
+      state: present
+  
+# Update a group
+  - name: Update group
+    group:
+      name: guests
+      create_datacenter: false
+      users:
+        - john.smith@test.com
+      state: update
+  
+# Remove a group
+  - name: Remove group
+    group:
+      name: guests
+      state: absent
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+&nbsp;
 
-## Parameter Reference
+&nbsp;
 
-The following parameters are supported:
+# state: **present**
+```yaml
+  # Create a group
+  - name: Create group
+    group:
+      name: guests
+      create_datacenter: true
+      create_snapshot: true
+      reserve_ip: false
+      access_activity_log: false
+      state: present
+  
+```
+### Available parameters for state **present**:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| name | **yes** | string |  | The name of the group. |
-| create\_datacenter | no | boolean |  | Indicates if the group is allowed to create virtual data centers. |
-| create\_snapshot | no | boolean |  | Indicates if the group is allowed to create snapshots. |
-| reserve\_ip | no | boolean |  | Indicates if the group is allowed to reserve IP addresses. |
-| access\_activity\_log | no | boolean |  | Indicates if the group is allowed to access the activity log. |
-| create_pcc | no | boolean |  | Indicates if the group is allowed to create PCCs. |
-| s3_privilege | no | boolean |  | Indicates if the group is allowed to access s3. |
-| create_backup_unit | no | boolean |  | Indicates if the group is allowed to create backupunits. |
-| create_internet_access | no | boolean |  | Indicates if the group is allowed to create internet access.. |
-| create_k8s_cluster | no | boolean |  | Indicates if the group is allowed to create kubernetes clusters. |
-| users | no | list |  | A list of \(non-administrator\) user IDs or emails to associate with the group. Set to empty list \(`[]`\) to remove all users from the group. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the group. |
+  | create_datacenter | False | bool |  | Boolean value indicating if the group is allowed to create virtual data centers. |
+  | create_snapshot | False | bool |  | Boolean value indicating if the group is allowed to create snapshots. |
+  | reserve_ip | False | bool |  | Boolean value indicating if the group is allowed to reserve IP addresses. |
+  | access_activity_log | False | bool |  | Boolean value indicating if the group is allowed to access the activity log. |
+  | create_pcc | False | bool |  | Boolean value indicating if the group is allowed to create PCCs. |
+  | s3_privilege | False | bool |  | Boolean value indicating if the group has S3 privilege. |
+  | create_backup_unit | False | bool |  | Boolean value indicating if the group is allowed to create backup units. |
+  | create_internet_access | False | bool |  | Boolean value indicating if the group is allowed to create internet access. |
+  | create_k8s_cluster | False | bool |  | Boolean value indicating if the group is allowed to create k8s clusters. |
+  | create_flow_log | False | bool |  | Boolean value indicating if the group is allowed to create flowlogs. |
+  | access_and_manage_monitoring | False | bool |  | Privilege for a group to access and manage monitoring related functionality (access metrics, CRUD on alarms, alarm-actions etc) using Monotoring-as-a-Service (MaaS). |
+  | access_and_manage_certificates | False | bool |  | Privilege for a group to access and manage certificates. |
+  | users | False | list |  | A list of (non-administrator) user IDs or emails to associate with the group. Set to empty list ([]) to remove all users from the group. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove a group
+  - name: Remove group
+    group:
+      name: guests
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the group. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update a group
+  - name: Update group
+    group:
+      name: guests
+      create_datacenter: false
+      users:
+        - john.smith@test.com
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | name | True | str |  | The name of the group. |
+  | create_datacenter | False | bool |  | Boolean value indicating if the group is allowed to create virtual data centers. |
+  | create_snapshot | False | bool |  | Boolean value indicating if the group is allowed to create snapshots. |
+  | reserve_ip | False | bool |  | Boolean value indicating if the group is allowed to reserve IP addresses. |
+  | access_activity_log | False | bool |  | Boolean value indicating if the group is allowed to access the activity log. |
+  | create_pcc | False | bool |  | Boolean value indicating if the group is allowed to create PCCs. |
+  | s3_privilege | False | bool |  | Boolean value indicating if the group has S3 privilege. |
+  | create_backup_unit | False | bool |  | Boolean value indicating if the group is allowed to create backup units. |
+  | create_internet_access | False | bool |  | Boolean value indicating if the group is allowed to create internet access. |
+  | create_k8s_cluster | False | bool |  | Boolean value indicating if the group is allowed to create k8s clusters. |
+  | create_flow_log | False | bool |  | Boolean value indicating if the group is allowed to create flowlogs. |
+  | access_and_manage_monitoring | False | bool |  | Privilege for a group to access and manage monitoring related functionality (access metrics, CRUD on alarms, alarm-actions etc) using Monotoring-as-a-Service (MaaS). |
+  | access_and_manage_certificates | False | bool |  | Privilege for a group to access and manage certificates. |
+  | users | False | list |  | A list of (non-administrator) user IDs or emails to associate with the group. Set to empty list ([]) to remove all users from the group. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/user-management/s3key.md
+++ b/docs/api/user-management/s3key.md
@@ -10,7 +10,6 @@ This is a simple module that supports creating or removing S3Keys.
   - name: Create an s3key
     s3key:
       user_id: "{{ user_id }}"
-  
 
   - name: Update an s3key
     s3key:
@@ -68,6 +67,7 @@ This is a simple module that supports creating or removing S3Keys.
   | api_url | False | str |  | The Ionos API base URL. |
   | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
   | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | idempotency | False | bool | False | If a key already exists, don't create any more on further requests. |
   | wait | False | bool | True | Wait for the resource to be created before returning. |
   | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
   | state | False | str | present | Indicate desired state of the resource. |

--- a/docs/api/user-management/s3key.md
+++ b/docs/api/user-management/s3key.md
@@ -1,8 +1,39 @@
-# S3key
+# s3key
+
+This is a simple module that supports creating or removing S3Keys.
 
 ## Example Syntax
 
+
 ```yaml
+
+  - name: Create an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+  
+
+  - name: Update an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+      key_id: "00ca413c94eecc56857d"
+      active: False
+      state: update
+  
+
+  - name: Remove an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+      key_id: "00ca413c94eecc56857d"
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+<<<<<<< HEAD
     - name: Create an s3key
       s3key:
         user_id: "{{ user_id }}"
@@ -19,15 +50,84 @@
         user_id: "{{ user_id }}"
         key_id: "00ca413c94eecc56857d"
         state: absent
+=======
+  
+  - name: Create an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **present**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | active | False | bool |  | Denotes weather the S3 key is active. |
+  | user_id | True | str |  | The ID of the user |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| user\_id | **yes** | string |  | The unique ID of the user. |
-| key\_id | **yes** | string |  | The ID of the key. Required only for state = 'update' or state = 'absent' |
-| active | no | boolean |  | State of the key. |
+&nbsp;
+# state: **absent**
+```yaml
+  
+  - name: Remove an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+      key_id: "00ca413c94eecc56857d"
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | user_id | True | str |  | The ID of the user |
+  | key_id | True | str |  | The ID of the S3 key. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  
+  - name: Update an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+      key_id: "00ca413c94eecc56857d"
+      active: False
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | active | False | bool |  | Denotes weather the S3 key is active. |
+  | user_id | True | str |  | The ID of the user |
+  | key_id | True | str |  | The ID of the S3 key. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/user-management/share.md
+++ b/docs/api/user-management/share.md
@@ -1,8 +1,48 @@
-# Share
+# share
+
+This module allows you to add, update or remove resource shares.
 
 ## Example Syntax
 
+
 ```yaml
+# Create shares
+  - name: Create share
+    share:
+      group: Demo
+      edit_privilege: true
+      share_privilege: true
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+        - ba7efccb-a761-11e7-90a7-525400f64d8d
+      state: present
+  
+# Update shares
+  - name: Update shares
+    share:
+      group: Demo
+      edit_privilege: false
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+      state: update
+  
+# Remove shares
+  - name: Remove shares
+    share:
+      group: Demo
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+        - ba7efccb-a761-11e7-90a7-525400f64d8d
+      state: absent
+  
+```
+&nbsp;
+
+&nbsp;
+
+# state: **present**
+```yaml
+<<<<<<< HEAD
     - name: Create shares
       share:
         group: Demo
@@ -20,22 +60,96 @@
         resource_ids:
           - b50ba74e-b585-44d6-9b6e-68941b2ce98e
         state: update
+=======
+  # Create shares
+  - name: Create share
+    share:
+      group: Demo
+      edit_privilege: true
+      share_privilege: true
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+        - ba7efccb-a761-11e7-90a7-525400f64d8d
+      state: present
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+### Available parameters for state **present**:
+&nbsp;
 
-## Parameter Reference
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | edit_privilege | False | bool |  | Boolean value indicating that the group has permission to edit privileges on the resource. |
+  | share_privilege | False | bool |  | Boolean value indicating that the group has permission to share the resource. |
+  | group | True | str |  | The name or ID of the group. |
+  | resource_ids | True | list |  | A list of resource IDs to add, update or remove as shares. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
-The following parameters are supported:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| group | **yes** | string |  | The name or ID of the group. |
-| resource\_ids | **yes** | list |  | A list of resource IDs to add, update or remove as shares. |
-| edit\_privilege | no | boolean |  | Indicates that the group has permission to edit privileges on the resource. |
-| share\_privilege | no | boolean |  | Indicates that the group has permission to share the resource. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove shares
+  - name: Remove shares
+    share:
+      group: Demo
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+        - ba7efccb-a761-11e7-90a7-525400f64d8d
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
 
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | group | True | str |  | The name or ID of the group. |
+  | resource_ids | True | list |  | A list of resource IDs to add, update or remove as shares. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update shares
+  - name: Update shares
+    share:
+      group: Demo
+      edit_privilege: false
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | edit_privilege | False | bool |  | Boolean value indicating that the group has permission to edit privileges on the resource. |
+  | share_privilege | False | bool |  | Boolean value indicating that the group has permission to share the resource. |
+  | group | True | str |  | The name or ID of the group. |
+  | resource_ids | True | list |  | A list of resource IDs to add, update or remove as shares. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/api/user-management/user.md
+++ b/docs/api/user-management/user.md
@@ -1,8 +1,12 @@
-# User
+# user
+
+This module allows you to create, update or remove a user.
 
 ## Example Syntax
 
+
 ```yaml
+<<<<<<< HEAD
     - name: Create user
       user:
         firstname: John
@@ -39,25 +43,141 @@
       user:
         email: "{{ random_user }}"
         state: absent
+=======
+# Create a user
+  - name: Create user
+    user:
+      firstname: John
+      lastname: Doe
+      email: john.doe@example.com
+      user_password: secretpassword123
+      administrator: true
+      state: present
+  
+# Update a user
+  - name: Update user
+    user:
+      firstname: John II
+      lastname: Doe
+      email: john.doe@example.com
+      administrator: false
+      force_sec_auth: false
+      groups:
+        - Developers
+        - Testers
+      state: update
+  
+# Remove a user
+  - name: Remove user
+    user:
+      email: john.doe@example.com
+      state: absent
+  
+>>>>>>> 00db8fa... feat: generate docs (#61)
 ```
+&nbsp;
 
-## Parameter Reference
+&nbsp;
 
-The following parameters are supported:
+# state: **present**
+```yaml
+  # Create a user
+  - name: Create user
+    user:
+      firstname: John
+      lastname: Doe
+      email: john.doe@example.com
+      user_password: secretpassword123
+      administrator: true
+      state: present
+  
+```
+### Available parameters for state **present**:
+&nbsp;
 
-| Name | Required | Type | Default | Description |
-| :--- | :---: | :--- | :--- | :--- |
-| firstname | **yes**/no | string |  | The user's first name. Required for `state='present'` only. |
-| lastname | **yes**/no | string |  | The user's last name. Required for `state='present'` only. |
-| email | **yes** | string |  | The user's email. |
-| user\_password | **yes**/no | string |  | A password for the user. Required for `state='present'` only. |
-| administrator | no | boolean |  | Indicates if the user has administrative rights. |
-| force\_sec\_auth | no | boolean |  | Indicates if secure \(two-factor\) authentication should be forced for the user. |
-| groups | no | list |  | A list of group IDs or names where the user \(non-administrator\) is to be added. Set to empty list \(`[]`\) to remove the user from all groups. |
-| api\_url | no | string |  | The Ionos API base URL. |
-| username | no | string |  | The Ionos username. Overrides the IONOS\_USERNAME environement variable. |
-| password | no | string |  | The Ionos password. Overrides the IONOS\_PASSWORD environement variable. |
-| wait | no | boolean | true | Wait for the operation to complete before continuing. |
-| wait\_timeout | no | integer | 600 | The number of seconds until the wait ends. |
-| state | no | string | present | Indicate desired state of the resource: **present**, absent, update |
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | firstname | True | str |  | The user's first name. |
+  | lastname | True | str |  | The user's last name. |
+  | email | True | str |  | The user's email |
+  | user_password | True | str |  | A password for the user. |
+  | administrator | False | bool |  | Boolean value indicating if the user has administrative rights. |
+  | force_sec_auth | False | bool |  | Boolean value indicating if secure (two-factor) authentication should be forced for the user. |
+  | groups | False | list |  | A list of group IDs or names where the user (non-administrator) is to be added.Set to empty list ([]) to remove the user from all groups. |
+  | sec_auth_active | False | bool |  | Indicates if secure authentication is active for the user. |
+  | s3_canonical_user_id | False | str |  | Canonical (S3) ID of the user for a given identity. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
 
+&nbsp;
+
+&nbsp;
+# state: **absent**
+```yaml
+  # Remove a user
+  - name: Remove user
+    user:
+      email: john.doe@example.com
+      state: absent
+  
+```
+### Available parameters for state **absent**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | email | True | str |  | The user's email |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;
+# state: **update**
+```yaml
+  # Update a user
+  - name: Update user
+    user:
+      firstname: John II
+      lastname: Doe
+      email: john.doe@example.com
+      administrator: false
+      force_sec_auth: false
+      groups:
+        - Developers
+        - Testers
+      state: update
+  
+```
+### Available parameters for state **update**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  | firstname | False | str |  | The user's first name. |
+  | lastname | False | str |  | The user's last name. |
+  | email | True | str |  | The user's email |
+  | user_password | False | str |  | A password for the user. |
+  | administrator | False | bool |  | Boolean value indicating if the user has administrative rights. |
+  | force_sec_auth | False | bool |  | Boolean value indicating if secure (two-factor) authentication should be forced for the user. |
+  | groups | False | list |  | A list of group IDs or names where the user (non-administrator) is to be added.Set to empty list ([]) to remove the user from all groups. |
+  | sec_auth_active | False | bool |  | Indicates if secure authentication is active for the user. |
+  | s3_canonical_user_id | False | str |  | Canonical (S3) ID of the user for a given identity. |
+  | api_url | False | str |  | The Ionos API base URL. |
+  | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+  | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+  | wait | False | bool | True | Wait for the resource to be created before returning. |
+  | wait_timeout | False | int | 600 | How long before wait gives up, in seconds. |
+  | state | False | str | present | Indicate desired state of the resource. |
+
+&nbsp;
+
+&nbsp;

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -17,7 +17,7 @@
 * Compute Engine
     * [Cube template](api/compute-engine/cube_template.md)
     * [Datacenter](api/compute-engine/datacenter.md)
-    * [Firewall rule](api/compute-engine/firewallrule.md)
+    * [Firewall rule](api/compute-engine/firewall_rule.md)
     * [Image](api/compute-engine/image.md)
     * [IpBlock](api/compute-engine/ipblock.md)
     * [Lan](api/compute-engine/lan.md)

--- a/docs/templates/info_module.mustache
+++ b/docs/templates/info_module.mustache
@@ -1,0 +1,18 @@
+# {{module_name}}
+
+{{description}}
+
+## Example Syntax
+
+
+```yaml
+{{{ example }}}
+```
+### Available parameters:
+&nbsp;
+
+| Name | Required | Type | Default | Description |
+| :--- | :---: | :--- | :--- | :--- |
+{{#states_parameters}}
+| {{name}} | {{required}} | {{type}} | {{default}} | {{description}} |
+{{/states_parameters}}

--- a/docs/templates/module.mustache
+++ b/docs/templates/module.mustache
@@ -1,0 +1,32 @@
+# {{module_name}}
+
+{{description}}
+
+## Example Syntax
+
+
+```yaml
+{{{ example }}}
+```
+&nbsp;
+
+&nbsp;
+
+{{#states_parameters}}
+# state: **{{ state }}**
+```yaml
+  {{{ example }}}
+```
+### Available parameters for state **{{ state }}**:
+&nbsp;
+
+  | Name | Required | Type | Default | Description |
+  | :--- | :---: | :--- | :--- | :--- |
+  {{#parameters}}
+  | {{name}} | {{required}} | {{type}} | {{default}} | {{description}} |
+  {{/parameters}}
+
+&nbsp;
+
+&nbsp;
+{{/states_parameters}}

--- a/docs_generator.py
+++ b/docs_generator.py
@@ -1,0 +1,96 @@
+import chevron
+import copy
+import importlib
+import os
+import yaml
+from pathlib import Path
+
+
+def generate_doc_file(module, module_name, states_parameters, template_file):
+        with open(os.path.join('docs', os.path.join('templates', template_file)), 'r') as template_file:
+            target_directory = os.path.join('docs', os.path.join('api', module.DOC_DIRECTORY))
+            Path(target_directory).mkdir(parents=True, exist_ok=True)
+            target_filename = os.path.join(target_directory, module_name + '.md')
+
+            with open(target_filename, 'w') as target_file:
+                target_file.write(chevron.render(
+                    template_file,
+                    {
+                        'module_name': module_name,
+                        'description': ''.join(yaml.safe_load(module.DOCUMENTATION)['description']),
+                        'example': module.EXAMPLES,
+                        'states_parameters': states_parameters,
+                    },
+                ))
+                print('Generated docs for <{}> in {}'.format(module_name, target_filename))
+        return target_filename
+
+
+def generate_module_docs(module_name):
+    module = importlib.import_module('plugins.modules.' + module_name)
+
+    if module_name.endswith('_info'):
+        def available_in_state(option):
+            return state in option[1]['available']
+        state_parameters = []
+        for el in list(module.OPTIONS.items()):
+            el[1]['name'] = el[0]
+            el[1]['description'] = ''.join(el[1]['description'])
+            el[1]['required'] = el[1].get('required', []) is not []
+            state_parameters.append(el[1])
+        
+        target_filename = generate_doc_file(module, module_name, state_parameters, 'info_module.mustache')
+    else:
+        parameters_per_state = []
+        for state in module.STATES:
+            def available_in_state(option):
+                return state in option[1]['available']
+            state_parameters = []
+            for el in list(filter(available_in_state, copy.deepcopy(module.OPTIONS).items())):
+                el[1]['name'] = el[0]
+                el[1]['description'] = ''.join(el[1]['description'])
+                el[1]['required'] = state in el[1].get('required', [])
+                state_parameters.append(el[1])
+            parameters_per_state.append({
+                'state': state,
+                'parameters': state_parameters,
+                'example': module.EXAMPLE_PER_STATE.get(state),
+            })
+        target_filename = generate_doc_file(module, module_name, parameters_per_state, 'module.mustache')
+    return module.DOC_DIRECTORY, target_filename
+
+modules_to_generate = [
+    # 'cube_template', commented it before we change it to a regular info module
+    'datacenter',
+    'firewall_rule',
+    'image',
+    'ipblock',
+    'lan',
+    'nic_flowlog',
+    'nic',
+    'pcc',
+    'server',
+    'snapshot',
+    'volume',
+    'postgres_cluster',
+    'postgres_backup_info',
+    'postgres_cluster_info',
+    'backupunit',
+    'k8s_cluster',
+    'k8s_config',
+    'k8s_nodepool',
+    'nat_gateway_flowlog',
+    'nat_gateway_rule',
+    'nat_gateway',
+    'network_load_balancer_flowlog',
+    'network_load_balancer_rule',
+    'network_load_balancer',
+    'group',
+    's3key',
+    'share',
+    'user',
+]
+
+for module_name in modules_to_generate:
+    generate_module_docs(module_name)
+

--- a/plugins/modules/backupunit.py
+++ b/plugins/modules/backupunit.py
@@ -1,31 +1,9 @@
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-EXAMPLES = '''
-    - name: Create backupunit
-      backupunit:
-        backupunit_email: "{{ email }}"
-        backupunit_password: "{{ password }}"
-        name: "{{ name }}"
-
-    - name: Update a backupunit
-      backupunit:
-        backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
-        backupunit_email: "{{ updated_email }}"
-        backupunit_password:  "{{ updated_password }}"
-        state: update
-
-    - name: Remove backupunit
-      backupunit:
-        backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
-        state: absent
-'''
-
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 import re
+import yaml
+import copy
 
 HAS_SDK = True
 try:
@@ -36,6 +14,137 @@ try:
     from ionoscloud import ApiClient
 except ImportError:
     HAS_SDK = False
+    
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community',
+}
+
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'managed-backup'
+OBJECT_NAME = 'Backup Unit'
+STATES = ['present', 'absent', 'update']
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the virtual Backup Unit.'],
+        'required': ['present'],
+        'available': ['present', 'update', 'absent'],
+        'type': 'str',
+    },
+    'backupunit_id': {
+        'description': ['The ID of the virtual Backup Unit.'],
+        'required': ['update', 'absent'],
+        'available': ['update', 'absent'],
+        'type': 'str',
+    },
+    'backupunit_password': {
+        'description': ['The password of the Backup Unit.'],
+        'available': ['present'],
+        'no_log': True,
+        'type': 'str',
+    },
+    'backupunit_email': {
+        'description': ['The email of the Backup Unit.'],
+        'required': ['present'],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: backupunit
+short_description: Create or remove Backup Units
+description:
+     - This is a simple module that supports creating or removing Backup Units.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a Backup Unit
+  - name: Create Backup Unit
+    backupunit:
+      backupunit_email: "{{ email }}"
+      backupunit_password: "{{ password }}"
+      name: "{{ name }}"
+  ''',
+  'update' : '''# Update a Backup Unit
+  - name: Update a Backup Unit
+    backupunit:
+      backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
+      backupunit_email: "{{ updated_email }}"
+      backupunit_password:  "{{ updated_password }}"
+      state: update
+  ''',
+  'absent' : '''# Destroy a Backup Unit.
+  - name: Remove Backup Unit
+    backupunit:
+      backupunit_id: "2fac5a84-5cc4-4f85-a855-2c0786a4cdec"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_resource(resource_list, identity):
@@ -159,42 +268,30 @@ def update_backupunit(module, client):
         }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            backupunit_password=dict(type='str', no_log=True),
-            backupunit_email=dict(type='str'),
-            backupunit_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -205,46 +302,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new backupunit')
-            if not module.params.get('backupunit_email'):
-                module.fail_json(msg='backupunit_email parameter is required for a new backupunit')
-            if not module.params.get('backupunit_password'):
-                module.fail_json(msg='backupunit_password parameter is required for a new backupunit')
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-            try:
-                (backupunit_dict_array) = create_backupunit(module, api_client)
-                module.exit_json(**backupunit_dict_array)
 
-            except Exception as e:
-                module.fail_json(msg='failed to set user state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-        elif state == 'absent':
-            if not module.params.get('backupunit_id'):
-                module.fail_json(msg='backupunit_id parameter is required for deleting a backupunit.')
+    state = module.params.get('state')
 
-            try:
-                (result) = delete_backupunit(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set backupunit state: %s' % to_native(e))
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-        elif state == 'update':
-            if not module.params.get('backupunit_id'):
-                module.fail_json(msg='backupunit_id parameter is required for updating a backupunit.')
-
-            try:
-                (backupunit_dict_array) = update_backupunit(module, api_client)
-                module.exit_json(**backupunit_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set backupunit state: %s' % to_native(e))
-
+        try:
+            if state == 'present':
+                module.exit_json(**create_backupunit(module, api_client))
+            elif state == 'absent':
+                module.exit_json(**delete_backupunit(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_backupunit(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/cube_template.py
+++ b/plugins/modules/cube_template.py
@@ -3,6 +3,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+import copy
+import yaml
 
 __metaclass__ = type
 
@@ -19,6 +21,101 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present']
+OBJECT_NAME = 'CUBE template'
+
+OPTIONS = {
+    'template_id': {
+        'description': ['The ID of the template.'],
+        'available': STATES,
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: cube_template
+short_description: Retrieve one or more Cube templates.
+description:
+     - This is a simple module that supports retrieving one or more Cube templates
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+    - name: List templates
+      cube_template:
+        state: present
+      register: template_list
+
+    - name: Debug - Show Templates List
+      debug:
+        msg: "{{  template_list.template }}"
+
+    - name: Get template by template id
+      cube_template:
+        template_id: "{{ template_list.template['items'][0]['id'] }}"
+      register: template_response
+
+    - name: Debug - Show Template
+      debug:
+        msg: "{{ template_response.template }}"
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def get_template(module, client):
@@ -53,37 +150,30 @@ def get_template(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            template_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
 
     conf = {
         'username': username,
@@ -94,17 +184,34 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, 'present', OBJECT_NAME)
         try:
-            (template_dict_array) = get_template(module, api_client)
-            module.exit_json(**template_dict_array)
+            module.exit_json(**get_template(module, api_client))
         except Exception as e:
-            module.fail_json(msg='failed to get template: %s' % to_native(e))
+            module.fail_json(msg='failed to set {object_name} state present: {error}'.format(object_name=OBJECT_NAME, error=to_native(e)))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/firewall_rule.py
+++ b/plugins/modules/firewall_rule.py
@@ -3,12 +3,165 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+import copy
+import re
+import time
+import yaml
+
+
+HAS_SDK = True
+
+try:
+    import ionoscloud
+    from ionoscloud import __version__ as sdk_version
+    from ionoscloud.models import FirewallRule, FirewallruleProperties, Nic, NicProperties
+    from ionoscloud.rest import ApiException
+    from ionoscloud import ApiClient
+except ImportError:
+    HAS_SDK = False
+
+from ansible import __version__
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_native
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Firewall Rule'
+
+OPTIONS = {
+    'datacenter': {
+        'description': ['The datacenter name or UUID in which to operate.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'server': {
+        'description': ['The server name or UUID.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'nic': {
+        'description': ['The NIC name or UUID.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'name': {
+        'description': ['The name or UUID of the firewall rule.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'protocol': {
+        'description': ['The protocol for the firewall rule.'],
+        'required': ['present'],
+        'available': ['present', 'update'],
+        'choices': ['TCP', 'UDP', 'ICMP', 'ANY'],
+        'type': 'str',
+    },
+    'source_mac': {
+        'description': ['Only traffic originating from the respective MAC address is allowed. No value allows all source MAC addresses.'],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'source_ip': {
+        'description': ['Only traffic originating from the respective IPv4 address is allowed. No value allows all source IPs.'],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'target_ip': {
+        'description': [
+            'In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed.'
+            'No value allows all target IPs.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'port_range_start': {
+        'description': [
+            'Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Leave value empty to allow all ports.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'int',
+    },
+    'port_range_end': {
+        'description': [
+            'Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Leave value empty to allow all ports.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'int',
+    },
+    'icmp_type': {
+        'description': ['Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. No value allows all types.'],
+        'available': ['present', 'update'],
+        'type': 'int',
+    },
+    'icmp_code': {
+        'description': ['Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. No value allows all codes.'],
+        'available': ['present', 'update'],
+        'type': 'int',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
 
 DOCUMENTATION = '''
 ---
@@ -18,99 +171,16 @@ description:
      - This module allows you to create, update or remove a firewall rule.
 version_added: "2.2"
 options:
-  datacenter:
-    description:
-      - The datacenter name or UUID in which to operate.
-    required: true
-  server:
-    description:
-      - The server name or UUID.
-    required: true
-  nic:
-    description:
-      - The NIC name or UUID.
-    required: true
-  name:
-    description:
-      - The name or UUID of the firewall rule.
-    required: false
-  protocol:
-    description:
-      - The protocol for the firewall rule.
-    choices: [ "TCP", "UDP", "ICMP", "ANY" ]
-    required: true
-  source_mac:
-    description:
-      - Only traffic originating from the respective MAC address is allowed. No value allows all source MAC addresses.
-    required: false
-  source_ip:
-    description:
-      - Only traffic originating from the respective IPv4 address is allowed. No value allows all source IPs.
-    required: false
-  target_ip:
-    description:
-      - In case the target NIC has multiple IP addresses, only traffic directed to the respective IP address of the NIC is allowed.
-        No value allows all target IPs.
-    required: false
-  port_range_start:
-    description:
-      - Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen. Leave value empty to allow all ports.
-    required: false
-  port_range_end:
-    description:
-      - Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen. Leave value empty to allow all ports.
-    required: false
-  icmp_type:
-    description:
-      - Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. No value allows all types.
-    required: false
-  icmp_code:
-    description:
-      - Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. No value allows all codes.
-    required: false
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-    version_added: "2.4"
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
 requirements:
     - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
+    - "ionoscloud >= 6.0.0"
 author:
-    - "Matt Baldwin (baldwin@stackpointcloud.com)"
-    - "Ethan Devenport (@edevenport)"
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
 '''
 
-EXAMPLES = '''
-# Create a firewall rule
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a firewall rule
 - name: Create SSH firewall rule
   firewall_rule:
     datacenter: Virtual Datacenter
@@ -134,8 +204,8 @@ EXAMPLES = '''
     icmp_type: 8
     icmp_code: 0
     state: present
-
-# Update a firewall rule
+  ''',
+  'update' : '''# Update a firewall rule
 - name: Allow SSH access
   firewall_rule:
       datacenter: Virtual Datacenter
@@ -145,8 +215,8 @@ EXAMPLES = '''
       source_ip: 162.254.27.217
       source_mac: 01:23:45:67:89:00
       state: update
-
-# Remove a firewall rule
+  ''',
+  'absent' : '''# Remove a firewall rule
 - name: Remove public ping firewall rule
   firewall_rule:
     datacenter: Virtual Datacenter
@@ -154,84 +224,10 @@ EXAMPLES = '''
     nic: aa6c261b9c
     name: Allow Ping
     state: absent
-'''
+  ''',
+}
 
-RETURN = '''
----
-id:
-  description: UUID of the firewall rule.
-  returned: success
-  type: string
-  sample: be60aa97-d9c7-4c22-bebe-f5df7d6b675d
-name:
-  description: Name of the firewall rule.
-  returned: success
-  type: string
-  sample: Allow SSH
-protocol:
-  description: Protocol of the firewall rule.
-  returned: success
-  type: string
-  sample: TCP
-source_mac:
-  description: MAC address of the firewall rule.
-  returned: success
-  type: string
-  sample: 02:01:97:d7:ed:49
-source_ip:
-  description: Source IP of the firewall rule.
-  returned: success
-  type: string
-  sample: tcp
-target_ip:
-  description: Target IP of the firewall rule.
-  returned: success
-  type: string
-  sample: 10.0.0.1
-port_range_start:
-  description: Start port of the firewall rule.
-  returned: success
-  type: int
-  sample: 80
-port_range_end:
-  description: End port of the firewall rule.
-  returned: success
-  type: int
-  sample: 80
-icmp_type:
-  description: ICMP type of the firewall rule.
-  returned: success
-  type: int
-  sample: 8
-icmp_code:
-  description: ICMP code of the firewall rule.
-  returned: success
-  type: int
-  sample: 0
-'''
-
-import time
-import re
-
-HAS_SDK = True
-
-try:
-    import ionoscloud
-    from ionoscloud import __version__ as sdk_version
-    from ionoscloud.models import FirewallRule, FirewallruleProperties, Nic, NicProperties
-    from ionoscloud.rest import ApiException
-    from ionoscloud import ApiClient
-except ImportError:
-    HAS_SDK = False
-
-from ansible import __version__
-from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
-
-PROTOCOLS = ['TCP',
-             'UDP',
-             'ICMP',
-             'ANY']
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -512,51 +508,30 @@ def _get_resource_id(resource_list, identity, module, resource_type):
     module.fail_json(msg='%s \'%s\' could not be found.' % (resource_type, identity))
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            datacenter=dict(type='str', required=True),
-            server=dict(type='str', required=True),
-            nic=dict(type='str', required=True),
-            name=dict(type='str', required=True),
-            protocol=dict(type='str', choices=PROTOCOLS, required=False),
-            source_mac=dict(type='str', default=None),
-            source_ip=dict(type='str', default=None),
-            target_ip=dict(type='str', default=None),
-            port_range_start=dict(type='int', default=None),
-            port_range_end=dict(type='int', default=None),
-            icmp_type=dict(type='int', default=None),
-            icmp_code=dict(type='int', default=None),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -567,31 +542,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            try:
-                (result) = delete_firewall_rule(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set firewall rule state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'present':
-            try:
-                (firewall_rule_dict) = create_firewall_rule(module, api_client)
-                module.exit_json(**firewall_rule_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set firewall rules state: %s' % to_native(e))
 
-        elif state == 'update':
-            try:
-                (firewall_rule_dict) = update_firewall_rule(module, api_client)
-                module.exit_json(**firewall_rule_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update firewall rule: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_firewall_rule(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_firewall_rule(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_firewall_rule(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/group.py
+++ b/plugins/modules/group.py
@@ -6,116 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: group
-short_description: Create, update or remove a group.
-description:
-     - This module allows you to create, update or remove a group.
-version_added: "2.4"
-options:
-  name:
-    description:
-      - The name or ID of the group.
-    required: true
-  create_datacenter:
-    description:
-      - Boolean value indicating if the group is allowed to create virtual data centers.
-    required: false
-    default: None
-  create_snapshot:
-    description:
-      - Boolean value indicating if the group is allowed to create snapshots.
-    required: false
-    default: None
-  reserve_ip:
-    description:
-      - Boolean value indicating if the group is allowed to reserve IP addresses.
-    required: false
-    default: None
-  access_activity_log:
-    description:
-      - Boolean value indicating if the group is allowed to access the activity log.
-    required: false
-    default: None
-  users:
-    description:
-      - A list of (non-administrator) user IDs or emails to associate with the group.
-        Set to empty list ([]) to remove all users from the group.
-    required: false
-    default: None
-  api_url:
-    description:
-      - The Ionos Cloud API base URL.
-    required: false
-    default: null
-  username:
-    description:
-      - The Ionos Cloud username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos Cloud password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - Nurfet Becirevic (@nurfet-becirevic)
-    - Ethan Devenport (@edevenport)
-'''
-
-EXAMPLES = '''
-# Create a group
-- name: Create group
-  group:
-    name: guests
-    create_datacenter: true
-    create_snapshot: true
-    reserve_ip: false
-    access_activity_log: false
-    state: present
-
-# Update a group
-- name: Update group
-  group:
-    name: guests
-    create_datacenter: false
-    users:
-      - john.smith@test.com
-    state: update
-
-# Remove a group
-- name: Remove group
-  group:
-    name: guests
-    state: absent
-'''
-
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -131,6 +24,192 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'user-management'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Group'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the group.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'create_datacenter': {
+        'description': ['Boolean value indicating if the group is allowed to create virtual data centers.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'create_snapshot': {
+        'description': ['Boolean value indicating if the group is allowed to create snapshots.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'reserve_ip': {
+        'description': ['Boolean value indicating if the group is allowed to reserve IP addresses.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'access_activity_log': {
+        'description': ['Boolean value indicating if the group is allowed to access the activity log.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'create_pcc': {
+        'description': ['Boolean value indicating if the group is allowed to create PCCs.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    's3_privilege': {
+        'description': ['Boolean value indicating if the group has S3 privilege.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'create_backup_unit': {
+        'description': ['Boolean value indicating if the group is allowed to create backup units.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'create_internet_access': {
+        'description': ['Boolean value indicating if the group is allowed to create internet access.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'create_k8s_cluster': {
+        'description': ['Boolean value indicating if the group is allowed to create k8s clusters.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'create_flow_log': {
+        'description': ['Boolean value indicating if the group is allowed to create flowlogs.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'access_and_manage_monitoring': {
+        'description': [
+            'Privilege for a group to access and manage monitoring related functionality (access metrics, '
+            'CRUD on alarms, alarm-actions etc) using Monotoring-as-a-Service (MaaS).',
+        ],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'access_and_manage_certificates': {
+        'description': ['Privilege for a group to access and manage certificates.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'users': {
+        'description': [
+            'A list of (non-administrator) user IDs or emails to associate with the group. Set to empty list ([]) to remove all users from the group.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'list',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: group
+short_description: Create, update or remove a group.
+description:
+     - This module allows you to create, update or remove a group.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a group
+  - name: Create group
+    group:
+      name: guests
+      create_datacenter: true
+      create_snapshot: true
+      reserve_ip: false
+      access_activity_log: false
+      state: present
+  ''',
+  'update' : '''# Update a group
+  - name: Update group
+    group:
+      name: guests
+      create_datacenter: false
+      users:
+        - john.smith@test.com
+      state: update
+  ''',
+  'absent' : '''# Remove a group
+  - name: Remove group
+    group:
+      name: guests
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -414,54 +493,30 @@ def _get_resource_id(resource_list, identity, module, resource_type):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str', required=True),
-            create_datacenter=dict(type='bool', default=None),
-            create_snapshot=dict(type='bool', default=None),
-            reserve_ip=dict(type='bool', default=None),
-            access_activity_log=dict(type='bool', default=None),
-            create_pcc=dict(type='bool', default=None),
-            s3_privilege=dict(type='bool', default=None),
-            create_backup_unit=dict(type='bool', default=None),
-            create_internet_access=dict(type='bool', default=None),
-            create_k8s_cluster=dict(type='bool', default=None),
-            create_flow_log=dict(type='bool', default=None),
-            access_and_manage_monitoring=dict(type='bool', default=None),
-            access_and_manage_certificates=dict(type='bool', default=None),
-            users=dict(type='list', default=None),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -472,32 +527,42 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
+
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
         api_instance = ionoscloud.UserManagementApi(api_client)
 
-        if state == 'absent':
-            try:
-                (result) = delete_group(module, api_instance)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set group state: %s' % to_native(e))
-
-        elif state == 'present':
-            try:
-                (group_dict) = create_group(module, api_client)
-                module.exit_json(**group_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set group state: %s' % to_native(e))
-
-        elif state == 'update':
-            try:
-                (group_dict) = update_group(module, api_client)
-                module.exit_json(**group_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update group: %s' % to_native(e))
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_group(module, api_instance))
+            elif state == 'present':
+                module.exit_json(**create_group(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_group(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/image.py
+++ b/plugins/modules/image.py
@@ -2,10 +2,8 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible import __version__
 import re
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -17,6 +15,196 @@ try:
     from ionoscloud import ApiClient
 except ImportError:
     HAS_SDK = False
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['absent', 'update']
+OBJECT_NAME = 'Image'
+
+
+
+OPTIONS = {
+    'image_id': {
+        'description': ['The ID of the image.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'name': {
+        'description': ['The name of the image.'],
+        'available': STATES,
+        'type': 'str',
+    },
+    'description': {
+        'description': ['The description of the image.'],
+        'available': ['update'],
+        'type': 'str',
+    },
+    'cpu_hot_plug': {
+        'description': ['Hot-plug capable CPU (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'cpu_hot_unplug': {
+        'description': ['Hot-unplug capable CPU (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'ram_hot_plug': {
+        'description': ['Hot-plug capable RAM (no reboot required)'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'ram_hot_unplug': {
+        'description': ['Hot-unplug capable RAM (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'nic_hot_plug': {
+        'description': ['Hot-plug capable NIC (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'nic_hot_unplug': {
+        'description': ['Hot-unplug capable NIC (no reboot required)'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_scsi_hot_plug': {
+        'description': ['Hot-plug capable SCSI drive (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_scsi_hot_unplug': {
+        'description': ['Hot-unplug capable SCSI drive (no reboot required). Not supported with Windows VMs.'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_virtio_hot_plug': {
+        'description': ['Hot-plug capable Virt-IO drive (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_virtio_hot_unplug': {
+        'description': ['Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs.'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'licence_type': {
+        'description': ['OS type for this image.'],
+        'available': ['update'],
+        'required': ['update'],
+        'type': 'str',
+    },
+    'cloud_init': {
+        'description': ['Cloud init compatibility.'],
+        'available': ['update'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: image
+short_description: Update or destroy a Ionos Cloud Image.
+description:
+     - This is a simple module that supports updating or removing Images. This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'update' : '''# Update an image
+  - name: Update image
+      image:
+        image_id: "916b10ea-be31-11eb-b909-c608708a73fa"
+        name: "CentOS-8.3.2011-x86_64-boot-renamed.iso"
+        description: "An image used for testing the Ansible Module"
+        cpu_hot_plug: true
+        cpu_hot_unplug: false
+        ram_hot_plug: true
+        ram_hot_unplug: true
+        nic_hot_plug: true
+        nic_hot_unplug: true
+        disc_virtio_hot_plug: true
+        disc_virtio_hot_unplug: true
+        disc_scsi_hot_plug: true
+        disc_scsi_hot_unplug: false
+        licence_type: "LINUX"
+        cloud_init: V1
+        state: update
+  ''',
+  'absent' : '''# Destroy an image
+  - name: Delete image
+      image:
+        image_id: "916b10ea-be31-11eb-b909-c608708a73fa"
+        state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_resource(resource_list, identity):
@@ -30,7 +218,6 @@ def _get_resource(resource_list, identity):
             return resource.id
 
     return None
-
 
 
 def _get_request_id(headers):
@@ -124,56 +311,30 @@ def update_image(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            image_id=dict(type='str'),
-            name=dict(type='str'),
-            description=dict(type='str'),
-            cpu_hot_plug=dict(type='bool'),
-            cpu_hot_unplug=dict(type='bool'),
-            ram_hot_plug=dict(type='bool'),
-            ram_hot_unplug=dict(type='bool'),
-            nic_hot_plug=dict(type='bool'),
-            nic_hot_unplug=dict(type='bool'),
-            disc_scsi_hot_plug=dict(type='str'),
-            disc_scsi_hot_unplug=dict(type='bool'),
-            disc_virtio_hot_plug=dict(type='bool'),
-            disc_virtio_hot_unplug=dict(type='bool'),
-            licence_type=dict(type='str'),
-            cloud_init=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(
-            msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
-    if not state:
-        module.fail_json(msg='state parameter is required')
 
     conf = {
         'username': username,
@@ -184,36 +345,38 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            if not module.params.get('image_id'):
-                module.fail_json(
-                    msg='image_id parameter is required for deleting an image.')
-            try:
-                (changed) = delete_image(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(
-                    msg='failed to set image state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'update':
-            error_message = "%s parameter is required for updating an image."
-            if not module.params.get('image_id'):
-                module.fail_json(msg=error_message % 'image_id')
-            if not module.params.get('licence_type'):
-                module.fail_json(msg=error_message % 'licence_type')
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-            try:
-                (changed) = update_image(module, api_client)
-                module.exit_json(
-                    changed=changed)
-            except Exception as e:
-                module.fail_json(
-                    msg='failed to set image state: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_image(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_image(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/ipblock.py
+++ b/plugins/modules/ipblock.py
@@ -3,93 +3,11 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: ipblock
-short_description: Create or remove an IPBlock.
-description:
-     - This module allows you to create or remove an IPBlock.
-version_added: "2.4"
-options:
-  name:
-    description:
-      - The name or ID of the IPBlock.
-    required: false
-  location:
-    description:
-      - The datacenter location.
-    required: false
-    default: us/las
-    choices: [ "us/las", "us/ewr", "de/fra", "de/fkb", "de/txl", "gb/lhr" ]
-  size:
-    description:
-      - The number of IP addresses to allocate in the IPBlock.
-    required: false
-    default: 1
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - Nurfet Becirevic (@nurfet-becirevic)
-    - Ethan Devenport (@edevenport)
-'''
-
-EXAMPLES = '''
-# Create an IPBlock
-- name: Create IPBlock
-  ipblock:
-    name: staging
-    location: us/ewr
-    size: 2
-    state: present
-
-# Remove an IPBlock
-- name: Remove IPBlock
-  ipblock:
-    name: staging
-    state: absent
-'''
-
+import copy
 import re
+import yaml
+
+__metaclass__ = type
 
 HAS_SDK = True
 
@@ -107,14 +25,130 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
 
-LOCATIONS = ['us/las',
-             'us/ewr',
-             'de/fra',
-             'de/fkb',
-             'de/txl',
-             'gb/lhr'
-             ]
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'update', 'absent']
+OBJECT_NAME = 'IP Block'
 
+OPTIONS = {
+    'name': {
+        'description': ['The name or ID of the IPBlock.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'location': {
+        'description': ['The IP Block location.'],
+        'required': ['present'],
+        'choices': ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr'],
+        'default': 'us/las',
+        'available': ['present'],
+        'type': 'str',
+    },
+    'size': {
+        'description': ['The number of IP addresses to allocate in the IPBlock.'],
+        'available': ['present'],
+        'default': 1,
+        'type': 'int',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: ipblock
+short_description: Create or remove an IPBlock.
+description:
+     - This module allows you to create or remove an IPBlock.
+version_added: "2.4"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create an IPBlock
+- name: Create IPBlock
+  ipblock:
+    name: staging
+    location: us/ewr
+    size: 2
+    state: present
+  ''',
+  'update': '''# Update an IPBlock
+- name: Update ipblock
+  ipblock:
+    name: "staging - updated"
+    location: "us/ewr"
+    state: update
+  ''',
+  'absent' : '''# Remove an IPBlock
+- name: Remove IPBlock
+  ipblock:
+    name: staging
+    state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 def _get_request_id(headers):
     match = re.search('/requests/([-A-Fa-f0-9]+)/', headers)
@@ -295,43 +329,30 @@ def _get_resource(resource_list, identity):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            location=dict(type='str', choices=LOCATIONS, default='us/las'),
-            size=dict(type='int', default=1),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -342,34 +363,40 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
+
+
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
     state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-
-        if state == 'absent':
-            try:
-                (result) = delete_ipblock(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set IPBlock state: %s' % to_native(e))
-
-        elif state == 'present':
-            try:
-                (ipblock_dict) = reserve_ipblock(module, api_client)
-                module.exit_json(**ipblock_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set IPBlocks state: %s' % to_native(e))
-
-        elif state == 'update':
-            try:
-                (ipblock_dict) = update_ipblock(module, api_client)
-                module.exit_json(**ipblock_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set IPBlocks state: %s' % to_native(e))
-
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_ipblock(module, api_client))
+            elif state == 'present':
+                module.exit_json(**reserve_ipblock(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_ipblock(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/k8s_cluster.py
+++ b/plugins/modules/k8s_cluster.py
@@ -3,32 +3,10 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible import __version__
 import time
 import re
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+import copy
+import yaml
 
 HAS_SDK = True
-
-EXAMPLES = '''
-- name: Create k8s cluster
-  k8s_cluster:
-    name: "{{ cluster_name }}"
-
-- name: Delete k8s cluster
-  k8s_cluster:
-    k8s_cluster_id: "a9b56a4b-8033-4f1a-a59d-cfea86cfe40b"
-    state: absent
-
-- name: Update k8s cluster
-  k8s_cluster:
-    k8s_cluster_id: "89a5aeb0-d6c1-4cef-8f6b-2b9866d85850"
-    maintenance_window:
-      day_of_the_week: 'Tuesday'
-      time: '13:03:00'
-    k8s_version: 1.17.8
-    state: update
-'''
 
 try:
     import ionoscloud
@@ -38,6 +16,154 @@ try:
     from ionoscloud import ApiClient
 except ImportError:
     HAS_SDK = False
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'managed-kubernetes'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'K8s Cluster'
+
+OPTIONS = {
+    'cluster_name': {
+        'description': ['The name of the K8s cluster.'],
+        'available': ['present', 'update'],
+        'required': ['present', 'update'],
+        'type': 'str',
+    },
+    'k8s_cluster_id': {
+        'description': ['The ID of the K8s cluster.'],
+        'available': ['update', 'absent'],
+        'required': ['update', 'absent'],
+        'type': 'str',
+    },
+    'k8s_version': {
+        'description': ['The description of the virtual datacenter.'],
+        'available': ['present', 'update'],
+        'required': ['update'],
+        'type': 'str',
+    },
+    'maintenance_window': {
+        'description': ['The datacenter location.'],
+        'available': ['present', 'update'],
+        'required': ['update'],
+        'type': 'dict',
+    },
+    'public': {
+        'description': ['The datacenter location.'],
+        'available': ['present'],
+        'type': 'bool',
+    },
+    'api_subnet_allow_list': {
+        'description': ['The datacenter location.'],
+        'available': ['present', 'update'],
+        'type': 'list',
+        'elements': 'str',
+    },
+    's3_buckets_param': {
+        'description': ['The datacenter location.'],
+        'available': ['present', 'update'],
+        'type': 'list',
+        'elements': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: k8s_cluster
+short_description: Create or destroy a K8s Cluster.
+description:
+     - This is a simple module that supports creating or removing K8s Clusters.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create k8s cluster
+    k8s_cluster:
+      name: "{{ cluster_name }}"
+  ''',
+  'update' : '''
+  - name: Update k8s cluster
+    k8s_cluster:
+      k8s_cluster_id: "89a5aeb0-d6c1-4cef-8f6b-2b9866d85850"
+      maintenance_window:
+        day_of_the_week: 'Tuesday'
+        time: '13:03:00'
+      k8s_version: 1.17.8
+      state: update
+  ''',
+  'absent' : '''
+  - name: Delete k8s cluster
+    k8s_cluster:
+      k8s_cluster_id: "a9b56a4b-8033-4f1a-a59d-cfea86cfe40b"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -203,6 +329,7 @@ def _get_resource(resource_list, identity):
     return None
 
 
+<<<<<<< HEAD
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -237,13 +364,32 @@ def main():
     if not HAS_SDK:
         module.fail_json(
             msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+=======
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+>>>>>>> 00db8fa... feat: generate docs (#61)
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -254,50 +400,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-        if state == 'present':
-            if not module.params.get('cluster_name'):
-                module.fail_json(
-                    msg='cluster_name parameter is required for a new k8s cluster')
-            try:
-                (k8s_cluster_dict_array) = create_k8s_cluster(module, api_client)
-                module.exit_json(**k8s_cluster_dict_array)
-            except Exception as e:
-                module.fail_json(
-                    msg='failed to set k8s cluster state: %s' % to_native(e))
 
-        elif state == 'absent':
-            if not module.params.get('k8s_cluster_id'):
-                module.fail_json(
-                    msg='k8s_cluster_id parameter is required for deleting a k8s cluster.')
-            try:
-                (changed) = delete_k8s_cluster(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(
-                    msg='failed to set k8s cluster state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'update':
-            error_message = "%s parameter is required updating a k8s cluster."
-            if not module.params.get('k8s_cluster_id'):
-                module.fail_json(msg=error_message % 'k8s_cluster_id')
-            if not module.params.get('cluster_name'):
-                module.fail_json(msg=error_message % 'cluster_name')
-            if not module.params.get('k8s_version'):
-                module.fail_json(msg=error_message % 'k8s_version')
-            if not module.params.get('maintenance_window'):
-                module.fail_json(msg=error_message % 'maintenance_window')
 
-            try:
-                (changed) = update_k8s_cluster(module, api_client)
-                module.exit_json(
-                    changed=changed)
-            except Exception as e:
-                module.fail_json(
-                    msg='failed to set k8s cluster state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'present':
+                module.exit_json(**create_k8s_cluster(module, api_client))
+            elif state == 'absent':
+                module.exit_json(**delete_k8s_cluster(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_k8s_cluster(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/k8s_nodepool.py
+++ b/plugins/modules/k8s_nodepool.py
@@ -1,46 +1,11 @@
 import time
+import re
+import copy
+import yaml
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-EXAMPLES = '''
-- name: Create k8s cluster nodepool
-  k8s_nodepools:
-    cluster_name: "{{ name }}"
-    k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
-    datacenter_id: "4d495548-e330-434d-83a9-251bfa645875"
-    node_count: "1"
-    cpu_family: "AMD_OPTERON"
-    cores_count: "1"
-    ram_size: "2048"
-    availability_zone: "AUTO"
-    storage_type: "SSD"
-    storage_size: "100"
-
-- name: Delete k8s cluster nodepool
-  k8s_nodepools:
-    k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
-    nodepool_id: "e3aa6101-436f-49fa-9a8c-0d6617e0a277"
-    state: absent
-
-- name: Update k8s cluster nodepool
-  k8s_nodepools:
-    cluster_name: "{{ name }}"
-    k8s_cluster_id: "ed67d8b3-63c2-4abe-9bf0-073cee7739c9"
-    nodepool_id: "6e9efcc6-649a-4514-bee5-6165b614c89e"
-    node_count: 1
-    cores_count: "1"
-    maintenance_window:
-      day_of_the_week: 'Tuesday'
-      time: '13:03:00'
-    auto_scaling:
-      min_node_count: 1
-      max_node_count: 3
-    state: update
-'''
 
 HAS_SDK = True
+
 try:
     import ionoscloud
     from ionoscloud import __version__ as sdk_version
@@ -54,7 +19,246 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
-import re
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'managed-kubernetes'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'K8s Nodepool'
+
+OPTIONS = {
+    'nodepool_name': {
+        'description': ['The name of the K8s Nodepool.'],
+        'available': ['update', 'present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'k8s_cluster_id': {
+        'description': ['The ID of the K8s cluster.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'k8s_version': {
+        'description': ['The Kubernetes version the nodepool is running.'],
+        'available': ['update', 'present'],
+        'type': 'str',
+    },
+    'nodepool_id': {
+        'description': ['The ID of the K8s nodepool.'],
+        'available': ['update', 'absent'],
+        'required': ['update', 'absent'],
+        'type': 'str',
+    },
+    'datacenter_id': {
+        'description': ['A valid ID of the data center, to which the user has access.'],
+        'available': ['update', 'present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'lan_ids': {
+        'description': ['Array of additional LANs attached to worker nodes.'],
+        'available': ['update', 'present'],
+        'type': 'list',
+        'elements': 'int',
+    },
+    'node_count': {
+        'description': ['The number of nodes that make up the node pool.'],
+        'available': ['update', 'present'],
+        'type': 'int',
+    },
+    'cpu_family': {
+        'description': ['A valid CPU family name.'],
+        'available': ['present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'cores_count': {
+        'description': ['The number of cores for the node.'],
+        'available': ['present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'ram_size': {
+        'description': ['The RAM size for the node. Must be set in multiples of 1024 MB, with minimum size is of 2048 MB.'],
+        'available': ['present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'availability_zone': {
+        'description': ['The availability zone in which the target VM should be provisioned.'],
+        'available': ['present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'storage_type': {
+        'description': ['The type of hardware for the volume.'],
+        'available': ['present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'storage_size': {
+        'description': ['The size of the volume in GB. The size should be greater than 10GB.'],
+        'available': ['present'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'maintenance_window': {
+        'description': [
+            "The maintenance window is used for updating the software on the nodepool's nodes and for "
+            "upgrading the nodepool's K8s version. If no value is given, one is chosen dynamically, so there is no fixed default.",
+        ],
+        'available': ['present', 'update'],
+        'type': 'dict',
+    },
+    'labels': {
+        'description': ['Map of labels attached to node pool.'],
+        'available': ['present',],
+        'type': 'dict',
+    },
+    'annotations': {
+        'description': ['Map of annotations attached to node pool.'],
+        'available': ['present',],
+        'type': 'dict',
+    },
+    'auto_scaling': {
+        'description': ['Property to be set when auto-scaling needs to be enabled for the nodepool. By default, auto-scaling is not enabled.'],
+        'available': ['present', 'update'],
+        'type': 'dict',
+    },
+    'public_ips': {
+        'description': [
+            'Optional array of reserved public IP addresses to be used by the nodes. IPs must be from same location as the data center '
+            'used for the node pool. The array must contain one more IP than maximum number possible number of nodes (nodeCount+1 for '
+            'fixed number of nodes or maxNodeCount+1 when auto scaling is used). The extra IP is used when the nodes are rebuilt.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'list',
+        'elements': 'str',
+    },
+    'gateway_ip': {
+        'description': [
+            "Public IP address for the gateway performing source NAT for the node pool's nodes belonging to a private cluster. "
+            "Required only if the node pool belongs to a private cluster.",
+        ],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: k8s_nodepool
+short_description: Create or destroy K8s Nodepools
+description:
+     - This is a simple module that supports creating or removing K8s Nodepools.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create k8s cluster nodepool
+    k8s_nodepools:
+      cluster_name: "{{ name }}"
+      k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
+      datacenter_id: "4d495548-e330-434d-83a9-251bfa645875"
+      node_count: "1"
+      cpu_family: "AMD_OPTERON"
+      cores_count: "1"
+      ram_size: "2048"
+      availability_zone: "AUTO"
+      storage_type: "SSD"
+      storage_size: "100"
+  ''',
+  'update' : '''
+  - name: Update k8s cluster nodepool
+    k8s_nodepools:
+      cluster_name: "{{ name }}"
+      k8s_cluster_id: "ed67d8b3-63c2-4abe-9bf0-073cee7739c9"
+      nodepool_id: "6e9efcc6-649a-4514-bee5-6165b614c89e"
+      node_count: 1
+      cores_count: "1"
+      maintenance_window:
+        day_of_the_week: 'Tuesday'
+        time: '13:03:00'
+      auto_scaling:
+        min_node_count: 1
+        max_node_count: 3
+      state: update
+  ''',
+  'absent' : '''
+  - name: Delete k8s cluster nodepool
+    k8s_nodepools:
+      k8s_cluster_id: "a0a65f51-4d3c-438c-9543-39a3d7668af3"
+      nodepool_id: "e3aa6101-436f-49fa-9a8c-0d6617e0a277"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -260,6 +464,7 @@ def _get_resource(resource_list, identity):
     return None
 
 
+<<<<<<< HEAD
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -311,13 +516,32 @@ def main():
     )
     if not HAS_SDK:
         module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+=======
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+>>>>>>> 00db8fa... feat: generate docs (#61)
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -328,61 +552,44 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'present':
-            error_message = "%s parameter is required updating a k8s nodepool"
-            if not module.params.get('nodepool_name'):
-                module.fail_json(msg=error_message % 'nodepool_name')
-            if not module.params.get('k8s_cluster_id'):
-                module.fail_json(msg=error_message % 'k8s_cluster_id')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg=error_message % 'datacenter_id')
-            if not (module.params.get('node_count') or module.params.get('auto_scaling')) :
-                module.fail_json(msg=error_message % 'node_count or auto_scaling')
-            if not module.params.get('cpu_family'):
-                module.fail_json(msg=error_message % 'cpu_family')
-            if not module.params.get('cores_count'):
-                module.fail_json(msg=error_message % 'cores_count')
-            if not module.params.get('ram_size'):
-                module.fail_json(msg=error_message % 'ram_size')
-            if not module.params.get('availability_zone'):
-                module.fail_json(msg=error_message % 'availability_zone')
-            if not module.params.get('storage_type'):
-                module.fail_json(msg=error_message % 'storage_type')
-            if not module.params.get('storage_size'):
-                module.fail_json(msg=error_message % 'storage_size')
-            try:
-                (k8s_nodepool_dict_array) = create_k8s_cluster_nodepool(module, api_client)
-                module.exit_json(**k8s_nodepool_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set k8s cluster nodepool state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'absent':
-            if not module.params.get('k8s_cluster_id'):
-                module.fail_json(msg='k8s_cluster_id parameter is required deleting a k8s nodepool.')
-            if not module.params.get('nodepool_id'):
-                module.fail_json(msg='nodepool_id parameter is required deleting a k8s nodepool.')
 
-            try:
-                (result) = delete_k8s_cluster_nodepool(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set k8s nodepool state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-        elif state == 'update':
-            if not module.params.get('k8s_cluster_id'):
-                module.fail_json(msg='k8s_cluster_id parameter is required updating a nodepool.')
-            if not module.params.get('nodepool_id'):
-                module.fail_json(msg='nodepool_id parameter is required updating a nodepool.')
-            try:
-                (k8s_nodepool_dict_array) = update_k8s_cluster_nodepool(module, api_client)
-                module.exit_json(**k8s_nodepool_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set k8s nodepool state: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+        if state == 'present' and not module.params.get('node_count') and not module.params.get('auto_scaling'):
+            module.fail_json(
+                msg='either node_count or auto_scaling parameter is required for {object_name} state present'.format(object_name=OBJECT_NAME),
+            )
+        try:
+            if state == 'present':
+                module.exit_json(**create_k8s_cluster_nodepool(module, api_client))
+            elif state == 'absent':
+                module.exit_json(**delete_k8s_cluster_nodepool(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_k8s_cluster_nodepool(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/lan.py
+++ b/plugins/modules/lan.py
@@ -3,107 +3,9 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: lan
-short_description: Create, update or remove a LAN.
-description:
-     - This module allows you to create or remove a LAN.
-version_added: "2.4"
-options:
-  datacenter:
-    description:
-      - The datacenter name or UUID in which to operate.
-    required: true
-  name:
-    description:
-      - The name or ID of the LAN.
-    required: false
-  public:
-    description:
-      - If true, the LAN will have public Internet access.
-    required: false
-    default: true
-  ip_failover:
-    description:
-      - The IP failover group.
-    required: false
-  api_url:
-    description:
-      - The Ionos Cloud API base URL.
-    required: false
-    default: null
-  username:
-    description:
-      - The Ionos Cloud username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos Cloud password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - Nurfet Becirevic (@nurfet-becirevic)
-    - Ethan Devenport (@edevenport)
-'''
-
-EXAMPLES = '''
-# Create a LAN
-- name: Create private LAN
-  lan:
-    datacenter: Virtual Datacenter
-    name: nameoflan
-    public: false
-    state: present
-
-# Update a LAN
-- name: Update LAN
-  lan:
-    datacenter: Virtual Datacenter
-    name: nameoflan
-    public: true
-    ip_failover:
-          208.94.38.167: 1de3e6ae-da16-4dc7-845c-092e8a19fded
-          208.94.38.168: 8f01cbd3-bec4-46b7-b085-78bb9ea0c77c
-    state: update
-
-# Remove a LAN
-- name: Remove LAN
-  lan:
-    datacenter: Virtual Datacenter
-    name: nameoflan
-    state: absent
-'''
-
+import copy
 import re
+import yaml
 
 HAS_SDK = True
 
@@ -119,6 +21,147 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'LAN'
+
+OPTIONS = {
+    'datacenter': {
+        'description': ['The datacenter name or UUID in which to operate.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'name': {
+        'description': ['The name or ID of the LAN.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'pcc_id': {
+        'description': ['The ID of the PCC.'],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'ip_failover': {
+        'description': ['The IP failover group.'],
+        'available': ['present', 'update'],
+        'type': 'list',
+        'elements': 'dict',
+    },
+    'public': {
+        'description': ['If true, the LAN will have public Internet access.'],
+        'available': ['present', 'update'],
+        'default': False,
+        'type': 'bool',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: lan
+short_description: Create, update or remove a LAN.
+description:
+     - This module allows you to create or remove a LAN.
+version_added: "2.4"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a LAN
+- name: Create private LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    public: false
+    state: present
+  ''',
+  'update' : '''# Update a LAN
+- name: Update LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    public: true
+    ip_failover:
+          208.94.38.167: 1de3e6ae-da16-4dc7-845c-092e8a19fded
+          208.94.38.168: 8f01cbd3-bec4-46b7-b085-78bb9ea0c77c
+    state: update
+  ''',
+  'absent' : '''# Remove a LAN
+- name: Remove LAN
+  lan:
+    datacenter: Virtual Datacenter
+    name: nameoflan
+    state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -322,44 +365,30 @@ def _get_resource(resource_list, identity):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            datacenter=dict(type='str', required=True),
-            name=dict(type='str'),
-            pcc_id=dict(type='str'),
-            public=dict(type='bool', default=False),
-            ip_failover=dict(type='list', elements='dict'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -370,31 +399,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            try:
-                (result) = delete_lan(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set LAN state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'present':
-            try:
-                (lan_dict) = create_lan(module, api_client)
-                module.exit_json(**lan_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set LANs state: %s' % to_native(e))
 
-        elif state == 'update':
-            try:
-                (lan_dict) = update_lan(module, api_client)
-                module.exit_json(**lan_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update LAN: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_lan(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_lan(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_lan(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/nat_gateway_flowlog.py
+++ b/plugins/modules/nat_gateway_flowlog.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -23,8 +25,168 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'natgateway'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Flowlog'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the flowlog.'],
+        'available': STATES,
+        'required': ['present'],
+        'type': 'str',
+    },
+    'action': {
+        'description': ['Specifies the traffic action pattern.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'direction': {
+        'description': ['Specifies the traffic direction pattern.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'bucket': {
+        'description': ['S3 bucket name of an existing IONOS Cloud S3 bucket.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'datacenter_id': {
+        'description': ['The ID of the datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'nat_gateway_id': {
+        'description': ['The ID of the NAT Gateway.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'flowlog_id': {
+        'description': ['The ID of the Flowlog.'],
+        'available': ['absent', 'update'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: nat_gateway_flowlog
+short_description: Create or destroy a Ionos Cloud NATGateway Flowlog.
+description:
+     - This is a simple module that supports creating or removing NATGateway Flowlogs.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      name: "{{ name }}"
+      action: "ACCEPTED"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      wait: true
+    register: nat_gateway_flowlog_response
+  ''',
+  'update' : '''
+  - name: Update NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
+      name: "{{ name }}"
+      action: "ALL"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      wait: true
+      state: update
+    register: nat_gateway_flowlog_update_response
+  ''',
+  'absent' : '''
+  - name: Delete NAT Gateway Flowlog
+    nat_gateway_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      flowlog_id: "{{ nat_gateway_flowlog_response.flowlog.id }}"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_resource(resource_list, identity):
@@ -232,46 +394,30 @@ def remove_nat_gateway_flowlog(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            action=dict(type='str'),
-            direction=dict(type='str'),
-            bucket=dict(type='str'),
-            datacenter_id=dict(type='str'),
-            server_id=dict(type='str'),
-            flowlog_id=dict(type='str'),
-            nat_gateway_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -282,53 +428,44 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-        if state == 'absent':
-            if not (module.params.get('name') or module.params.get('nat_gateway_id')):
-                module.fail_json(
-                    msg='name parameter or nat_gateway_id parameter are required deleting a NAT Gateway Flowlog.')
-            try:
-                (result) = remove_nat_gateway_flowlog(module, api_client)
-                module.exit_json(**result)
 
-            except Exception as e:
-                module.fail_json(msg='failed to set NAT Gateway state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new NAT Gateway Flowlog')
-            if not module.params.get('action'):
-                module.fail_json(msg='action parameter is required for a new NAT Gateway Flowlog')
-            if not module.params.get('direction'):
-                module.fail_json(msg='direction parameter is required for a new NAT Gateway Flowlog')
-            if not module.params.get('bucket'):
-                module.fail_json(msg='bucket parameter is required for a new NAT Gateway Flowlog')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for a new NAT Gateway Flowlog')
-            if not module.params.get('nat_gateway_id'):
-                module.fail_json(msg='nat_gateway_id parameter is required for a new NAT Gateway Flowlog')
 
-            try:
-                (nat_gateway_flowlog_dict) = create_nat_gateway_flowlog(module, api_client)
-                module.exit_json(**nat_gateway_flowlog_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set NAT Gateway Flowlog state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-        elif state == 'update':
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for updating a NAT Gateway Flowlog')
-            if not module.params.get('nat_gateway_id'):
-                module.fail_json(msg='nat_gateway_id parameter is required for updating a NAT Gateway Flowlog')
-            if not module.params.get('flowlog_id'):
-                module.fail_json(msg='flowlog_id parameter is required for updating a NAT Gateway Flowlog')
-            try:
-                (nat_gateway_dict_array) = update_nat_gateway_flowlog(module, api_client)
-                module.exit_json(**nat_gateway_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to update the NAT Gateway Flowlog: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        if state == 'absent' and not module.params.get('name') and not module.params.get('flowlog_id'):
+            module.fail_json(msg='either name or flowlog_id parameter is required for {object_name} state absent'.format(object_name=OBJECT_NAME))
+
+        try:
+            if state == 'absent':
+                module.exit_json(**remove_nat_gateway_flowlog(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_nat_gateway_flowlog(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_nat_gateway_flowlog(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/nat_gateway_rule.py
+++ b/plugins/modules/nat_gateway_rule.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -23,8 +25,201 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'natgateway'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'NAT Gateway rule'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the NAT Gateway rule.'],
+        'available': STATES,
+        'required': ['present'],
+        'type': 'str',
+    },
+    'type': {
+        'description': ['Type of the NAT Gateway rule.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'protocol': {
+        'description': ["Protocol of the NAT Gateway rule. Defaults to ALL. If protocol is 'ICMP' then targetPortRange start and end cannot be set."],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'source_subnet': {
+        'description': [
+            'Source subnet of the NAT Gateway rule. For SNAT rules it specifies which packets this '
+            'translation rule applies to based on the packets source IP address.',
+        ],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'public_ip': {
+        'description': [
+            'Public IP address of the NAT Gateway rule. Specifies the address used for masking outgoing '
+            'packets source address field. Should be one of the customer reserved IP address already configured on the NAT Gateway resource.',
+        ],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'target_subnet': {
+        'description': [
+            'Target or destination subnet of the NAT Gateway rule. For SNAT rules it specifies which packets '
+            'this translation rule applies to based on the packets destination IP address. If none is provided, rule will match any address.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'target_port_range': {
+        'description': [
+            'Target port range of the NAT Gateway rule. For SNAT rules it specifies which packets this translation '
+            'rule applies to based on destination port. If none is provided, rule will match any port.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'datacenter_id': {
+        'description': ['The ID of the datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'nat_gateway_id': {
+        'description': ['The ID of the NAT Gateway.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'nat_gateway_rule_id': {
+        'description': ['The ID of the NAT Gateway rule.'],
+        'available': ['update', 'absent'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: nat_gateway_rule
+short_description: Create or destroy a Ionos Cloud NATGateway rule.
+description:
+     - This is a simple module that supports creating or removing NATGateway rules.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      name: "{{ name }}"
+      type: "SNAT"
+      protocol: "TCP"
+      source_subnet: "10.0.1.0/24"
+      target_subnet: "10.0.1.0"
+      target_port_range:
+        start: 10000
+        end: 20000
+      public_ip: "{{ ipblock_response.ipblock.properties.ips[0] }}"
+      wait: true
+    register: nat_gateway_rule_response
+  ''',
+  'update' : '''
+  - name: Update NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
+      public_ip: "{{ ipblock_response.ipblock.properties.ips[1] }}"
+      name: "{{ name }} - UPDATED"
+      type: "SNAT"
+      protocol: "TCP"
+      source_subnet: "10.0.1.0/24"
+      wait: true
+      state: update
+    register: nat_gateway_rule_update_response
+  ''',
+  'absent' : '''
+  - name: Delete NAT Gateway Rule
+    nat_gateway_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      nat_gateway_id: "{{ nat_gateway_response.nat_gateway.id }}"
+      nat_gateway_rule_id: "{{ nat_gateway_rule_response.nat_gateway_rule.id }}"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_resource(resource_list, identity):
@@ -248,52 +443,30 @@ def remove_nat_gateway_rule(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            type=dict(type='str'),
-            protocol=dict(type='str'),
-            source_subnet=dict(type='str'),
-            public_ip=dict(type='str'),
-            target_subnet=dict(type='str'),
-            datacenter_id=dict(type='str'),
-            nat_gateway_id=dict(type='str'),
-            nat_gateway_rule_id=dict(type='str'),
-            target_port_range=dict(
-                type='dict',
-                start=dict(type='int'),
-                end=dict(type='int')
-            ),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -304,59 +477,46 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new NAT Gateway Rule')
-            if not module.params.get('source_subnet'):
-                module.fail_json(msg='source_subnet parameter is required for a new NAT Gateway Rule')
-            if not module.params.get('public_ip'):
-                module.fail_json(msg='public_ip parameter is required for a new NAT Gateway Rule')
-            if not module.params.get('nat_gateway_id'):
-                module.fail_json(msg='nat_gateway_id parameter is required for a new NAT Gateway Rule')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for a new NAT Gateway Rule')
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-            try:
-                (nat_gateway_rule_dict) = create_nat_gateway_rule(module, api_client)
-                module.exit_json(**nat_gateway_rule_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set NAT Gateway Rule state: %s' % to_native(e))
 
-        elif state == 'update':
-            if not (module.params.get('name') or module.params.get('nat_gateway_id')):
-                module.fail_json(
-                    msg='name parameter or nat_gateway_id parameter are required for updating a NAT Gateway Rule.')
-            if not module.params.get('nat_gateway_rule_id'):
-                module.fail_json(msg='nat_gateway_rule_id parameter is required for updating a NAT Gateway Rule.')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for updating a NAT Gateway Rule.')
-            try:
-                (nat_gateway_rule_dict) = update_nat_gateway_rule(module, api_client)
-                module.exit_json(**nat_gateway_rule_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update the NAT Gateway: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-        elif state == 'absent':
-            if not (module.params.get('name') or module.params.get('nat_gateway_id')):
-                module.fail_json(
-                    msg='name parameter or nat_gateway_id parameter are required for deleting a NAT Gateway Rule.')
-            if not module.params.get('nat_gateway_rule_id'):
-                module.fail_json(msg='nat_gateway_rule_id parameter is required for deleting a NAT Gateway Rule.')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for deleting a NAT Gateway Rule.')
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-            try:
-                (result) = remove_nat_gateway_rule(module, api_client)
-                module.exit_json(**result)
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-            except Exception as e:
-                module.fail_json(msg='failed to set NAT Gateway Rule state: %s' % to_native(e))
+        if state in ['absent', 'update'] and not module.params.get('name') and not module.params.get('nat_gateway_rule_id'):
+            module.fail_json(
+                msg='either name or nat_gateway_rule_id parameter is required for {object_name} state present'.format(object_name=OBJECT_NAME),
+            )
 
+        try:
+            if state == 'present':
+                module.exit_json(**create_nat_gateway_rule(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_nat_gateway_rule(module, api_client))
+            elif state == 'absent':
+                module.exit_json(**remove_nat_gateway_rule(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/network_load_balancer.py
+++ b/plugins/modules/network_load_balancer.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -23,8 +25,169 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'networkloadbalancer'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Network Loadbalancer'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the Network Loadbalancer forwarding rule.'],
+        'available': STATES,
+        'required': ['present', 'update'],
+        'type': 'str',
+    },
+    'listener_lan': {
+        'description': ['ID of the listening LAN (inbound).'],
+        'available': ['present', 'update'],
+        'required': ['present', 'update'],
+        'type': 'str',
+    },
+    'ips': {
+        'description': [
+            'Collection of the Network Load Balancer IP addresses. (Inbound and outbound) '
+            'IPs of the listenerLan must be customer-reserved IPs for public Load Balancers, and private IPs for private Load Balancers.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'list',
+    },
+    'target_lan': {
+        'description': ['ID of the balanced private target LAN (outbound).'],
+        'available': ['present', 'update'],
+        'required': ['present', 'update'],
+        'type': 'str',
+    },
+    'lb_private_ips': {
+        'description': [
+            'Collection of private IP addresses with subnet mask of the Network Load Balancer. '
+            'IPs must contain a valid subnet mask. If no IP is provided, the system will generate an IP with /24 subnet.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'list',
+    },
+    'datacenter_id': {
+        'description': ['The ID of the datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'network_load_balancer_id': {
+        'description': ['The ID of the Network Loadbalancer.'],
+        'available': ['update', 'absent'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: network_load_balancer
+short_description: Create or destroy a Ionos Cloud NetworkLoadbalancer.
+description:
+     - This is a simple module that supports creating or removing NetworkLoadbalancers.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create Network Load Balancer
+    network_load_balancer:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      name: "{{ name }}"
+      ips:
+        - "10.12.118.224"
+      listener_lan: "{{ listener_lan.lan.id }}"
+      target_lan: "{{ target_lan.lan.id }}"
+      wait: true
+    register: nlb_response
+  ''',
+  'update' : '''
+  - name: Update Network Load Balancer
+    network_load_balancer:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      name: "{{ name }} - UPDATE"
+      listener_lan: "{{ listener_lan.lan.id }}"
+      target_lan: "{{ target_lan.lan.id }}"
+      wait: true
+      state: update
+    register: nlb_response_update
+  ''',
+  'absent' : '''
+  - name: Remove Network Load Balancer
+    network_load_balancer:
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      wait: true
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_resource(resource_list, identity):
@@ -228,45 +391,30 @@ def remove_nlb(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            listener_lan=dict(type='str'),
-            ips=dict(type='list', default=None),
-            target_lan=dict(type='str'),
-            lb_private_ips=dict(type='list', default=None),
-            datacenter_id=dict(type='str'),
-            network_load_balancer_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -277,53 +425,44 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-        if state == 'absent':
-            if not (module.params.get('name') or module.params.get('network_load_balancer_id')):
-                module.fail_json(
-                    msg='name parameter or network_load_balancer_id parameter are required for deleting a Network Load Balancer.')
-            try:
-                (result) = remove_nlb(module, api_client)
-                module.exit_json(**result)
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-            except Exception as e:
-                module.fail_json(msg='failed to set Network Load Balancer state: %s' % to_native(e))
 
-        elif state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new Network Load Balancer')
-            if not module.params.get('listener_lan'):
-                module.fail_json(msg='listener_lan parameter is required for a new Network Load Balancer')
-            if not module.params.get('target_lan'):
-                module.fail_json(msg='target_lan parameter is required for a new Network Load Balancer')
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-            try:
-                (nlb_dict) = create_nlb(module, api_client)
-                module.exit_json(**nlb_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set Network Load Balancer state: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-        elif state == 'update':
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for updating a Network Load Balancer')
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for updating a Network Load Balancer')
-            if not module.params.get('listener_lan'):
-                module.fail_json(msg='listener_lan parameter is required for updating a Network Load Balancer')
-            if not module.params.get('target_lan'):
-                module.fail_json(msg='target_lan parameter is required for updating a Network Load Balancer')
-            if not (module.params.get('name') or module.params.get('network_load_balancer_id')):
-                module.fail_json(
-                    msg='name parameter or network_load_balancer_id parameter are required updating a Network Load Balancer.')
-            try:
-                (nlb_dict) = update_nlb(module, api_client)
-                module.exit_json(**nlb_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update the Network Load Balancer: %s' % to_native(e))
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        if state == 'absent' and not module.params.get('name') and not module.params.get('network_load_balancer_id'):
+            module.fail_json(msg='either name or network_load_balancer_id parameter is required for {object_name} state present'.format(object_name=OBJECT_NAME))
+
+        try:
+            if state == 'absent':
+                module.exit_json(**remove_nlb(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_nlb(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_nlb(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/network_load_balancer_flowlog.py
+++ b/plugins/modules/network_load_balancer_flowlog.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -23,8 +25,167 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'networkloadbalancer'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Flowlog'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the flowlog.'],
+        'available': STATES,
+        'required': ['present'],
+        'type': 'str',
+    },
+    'action': {
+        'description': ['Specifies the traffic action pattern.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'direction': {
+        'description': ['Specifies the traffic direction pattern.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'bucket': {
+        'description': ['S3 bucket name of an existing IONOS Cloud S3 bucket.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'datacenter_id': {
+        'description': ['The ID of the datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'network_load_balancer_id': {
+        'description': ['The ID of the Network Loadbalancer.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'flowlog_id': {
+        'description': ['The ID of the Flowlog.'],
+        'available': STATES,
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: network_load_balancer_flowlog
+short_description: Create or destroy a Ionos Cloud NetworkLoadbalancer Flowlog.
+description:
+     - This is a simple module that supports creating or removing NetworkLoadbalancer Flowlogs.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      name: "{{ name }}"
+      action: "ACCEPTED"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      wait: true
+    register: nlb_flowlog_response
+  ''',
+  'update' : '''
+  - name: Update Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
+      name: "{{ name }}"
+      action: "ALL"
+      direction: "INGRESS"
+      bucket: "sdktest"
+      wait: true
+      state: update
+    register: nlb_flowlog_update_response
+  ''',
+  'absent' : '''
+  - name: Delete Network Load Balancer Flowlog
+    network_load_balancer_flowlog:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      flowlog_id: "{{ nlb_flowlog_response.flowlog.id }}"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_resource(resource_list, identity):
@@ -237,46 +398,30 @@ def remove_nlb_flowlog(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            action=dict(type='str'),
-            direction=dict(type='str'),
-            bucket=dict(type='str'),
-            datacenter_id=dict(type='str'),
-            server_id=dict(type='str'),
-            flowlog_id=dict(type='str'),
-            network_load_balancer_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -287,56 +432,44 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-        if state == 'absent':
-            if not (module.params.get('name') or module.params.get('network_load_balancer_id')):
-                module.fail_json(
-                    msg='name parameter or network_load_balancer_id parameter are required deleting a Network Load Balancer Flowlog.')
-            try:
-                (result) = remove_nlb_flowlog(module, api_client)
-                module.exit_json(**result)
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-            except Exception as e:
-                module.fail_json(msg='failed to set Network Load Balancer state: %s' % to_native(e))
 
-        elif state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new Network Load Balancer Flowlog')
-            if not module.params.get('action'):
-                module.fail_json(msg='action parameter is required for a new Network Load Balancer Flowlog')
-            if not module.params.get('direction'):
-                module.fail_json(msg='direction parameter is required for a new Network Load Balancer Flowlog')
-            if not module.params.get('bucket'):
-                module.fail_json(msg='bucket parameter is required for a new Network Load Balancer Flowlog')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for a new Network Load Balancer Flowlog')
-            if not module.params.get('network_load_balancer_id'):
-                module.fail_json(
-                    msg='network_load_balancer_id parameter is required for a new Network Load Balancer Flowlog')
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-            try:
-                (nlb_flowlog_dict) = create_nlb_flowlog(module, api_client)
-                module.exit_json(**nlb_flowlog_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set Network Load Balancer Flowlog state: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-        elif state == 'update':
-            if not module.params.get('datacenter_id'):
-                module.fail_json(msg='datacenter_id parameter is required for updating a Network Load Balancer Flowlog')
-            if not module.params.get('network_load_balancer_id'):
-                module.fail_json(
-                    msg='network_load_balancer_id parameter is required for updating a Network Load Balancer Flowlog')
-            if not module.params.get('flowlog_id'):
-                module.fail_json(msg='flowlog_id parameter is required for updating a Network Load Balancer Flowlog')
-            try:
-                (nlb_dict) = update_nlb_flowlog(module, api_client)
-                module.exit_json(**nlb_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update the Network Load Balancer Flowlog: %s' % to_native(e))
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        if state == 'absent' and not module.params.get('name') and not module.params.get('flowlog_id'):
+            module.fail_json(msg='either name or flowlog_id parameter is required for {object_name} state absent'.format(object_name=OBJECT_NAME))
+
+        try:
+            if state == 'absent':
+                module.exit_json(**remove_nlb_flowlog(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_nlb_flowlog(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_nlb_flowlog(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/network_load_balancer_rule.py
+++ b/plugins/modules/network_load_balancer_rule.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -24,8 +26,191 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'networkloadbalancer'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Network Loadbalancer forwarding rule'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the Network Loadbalancer forwarding rule.'],
+        'available': STATES,
+        'required': ['present'],
+        'type': 'str',
+    },
+    'algorithm': {
+        'description': ['Balancing algorithm.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'protocol': {
+        'description': ['Balancing protocol.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'listener_ip': {
+        'description': ['Listening (inbound) IP.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'listener_port': {
+        'description': ['Listening (inbound) port number; valid range is 1 to 65535.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'health_check': {
+        'description': ['Health check properties for Network Load Balancer forwarding rule.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'dict',
+    },
+    'targets': {
+        'description': ['Array of targets.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'list',
+        'elements': 'dict',
+    },
+    'datacenter_id': {
+        'description': ['The ID of the datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'network_load_balancer_id': {
+        'description': ['The ID of the Network Loadbalancer.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'forwarding_rule_id': {
+        'description': ['The ID of the Network Loadbalancer forwarding rule.'],
+        'available': ['update', 'absent'],
+        'type': 'str',
+    },
+
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: network_load_balancer_rule
+short_description: Create or destroy a Ionos Cloud NetworkLoadbalancer Flowlog rule.
+description:
+     - This is a simple module that supports creating or removing NATGateway Flowlog rules.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      name: "{{ name }}"
+      algorithm: "ROUND_ROBIN"
+      protocol: "TCP"
+      listener_ip: "10.12.118.224"
+      listener_port: "8081"
+      targets:
+        - ip: "22.231.2.2"
+          port: "8080"
+          weight: "123"
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      wait: true
+    register: nlb_forwarding_rule_response
+  ''',
+  'update' : '''
+  - name: Update Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
+      name: "{{ name }} - UPDATED"
+      algorithm: "ROUND_ROBIN"
+      protocol: "TCP"
+      wait: true
+      state: update
+    register: nlb_forwarding_rule_update_response
+  ''',
+  'absent' : '''
+  - name: Delete Network Load Balancer Forwarding Rule
+    network_load_balancer_rule:
+      datacenter_id: "{{ datacenter_response.datacenter.id }}"
+      network_load_balancer_id: "{{ nlb_response.network_load_balancer.id }}"
+      forwarding_rule_id: "{{ nlb_forwarding_rule_response.forwarding_rule.id }}"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_resource(resource_list, identity):
@@ -260,54 +445,30 @@ def remove_nlb_forwarding_rule(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            algorithm=dict(type='str'),
-            protocol=dict(type='str'),
-            listener_ip=dict(type='str'),
-            listener_port=dict(type='str'),
-            health_check=dict(type='dict',
-                              client_timeout=dict(type='str'),
-                              check_timeout=dict(type='str'),
-                              connect_timeout=dict(type='str'),
-                              target_timeout=dict(type='str'),
-                              retries=dict(type='str')
-                              ),
-            targets=dict(type='list', elements='dict'),
-            datacenter_id=dict(type='str'),
-            forwarding_rule_id=dict(type='str'),
-            network_load_balancer_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -318,70 +479,44 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-        if state == 'absent':
-            if not module.params.get('datacenter_id'):
-                module.fail_json(
-                    msg='datacenter_id parameter is required for deleting a Network Load Balancer Forwarding Rule')
-            if not module.params.get('network_load_balancer_id'):
-                module.fail_json(
-                    msg='network_load_balancer_id parameter is required for deleting a Network Load Balancer Forwarding Rule')
-            if not (module.params.get('name') or module.params.get('forwarding_rule_id')):
-                module.fail_json(
-                    msg='name parameter or forwarding_rule_id parameter are required for deleting a Network Load Balancer Forwarding Rule.')
-            try:
-                (result) = remove_nlb_forwarding_rule(module, api_client)
-                module.exit_json(**result)
 
-            except Exception as e:
-                module.fail_json(msg='failed to delete the Network Load Balancer: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('algorithm'):
-                module.fail_json(msg='algorithm parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('protocol'):
-                module.fail_json(msg='protocol parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('listener_ip'):
-                module.fail_json(
-                    msg='listener_ip parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('listener_port'):
-                module.fail_json(
-                    msg='listener_port parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('targets'):
-                module.fail_json(msg='targets parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('datacenter_id'):
-                module.fail_json(
-                    msg='datacenter_id parameter is required for a new Network Load Balancer Forwarding Rule')
-            if not module.params.get('network_load_balancer_id'):
-                module.fail_json(
-                    msg='network_load_balancer_id parameter is required for a new Network Load Balancer Forwarding Rule')
 
-            try:
-                (nlb_forwarding_rule_dict) = create_nlb_forwarding_rule(module, api_client)
-                module.exit_json(**nlb_forwarding_rule_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set Network Load Balancer Forwarding Rule state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-        elif state == 'update':
-            if not module.params.get('datacenter_id'):
-                module.fail_json(
-                    msg='datacenter_id parameter is required for updating a Network Load Balancer Forwarding Rule')
-            if not module.params.get('network_load_balancer_id'):
-                module.fail_json(
-                    msg='network_load_balancer_id parameter is required for updating a Network Load Balancer Forwarding Rule')
-            if not (module.params.get('name') or module.params.get('forwarding_rule_id')):
-                module.fail_json(
-                    msg='name parameter or forwarding_rule_id parameter are required deleting a Network Load Balancer Forwarding Rule.')
-            try:
-                (nlb_dict) = update_nlb_forwarding_rule(module, api_client)
-                module.exit_json(**nlb_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update the Network Load Balancer Forwarding Rule: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        if state in ['absent', 'update'] and not module.params.get('name') and not module.params.get('forwarding_rule_id'):
+            module.fail_json(msg='either name or forwarding_rule_id parameter is required for {object_name} state present'.format(object_name=OBJECT_NAME))
+
+        try:
+            if state == 'absent':
+                module.exit_json(**remove_nlb_forwarding_rule(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_nlb_forwarding_rule(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_nlb_forwarding_rule(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/nic.py
+++ b/plugins/modules/nic.py
@@ -4,129 +4,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-__metaclass__ = type
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: nic
-short_description: Create, Update or Remove a NIC.
-description:
-     - This module allows you to create, update or remove a NIC.
-version_added: "2.0"
-options:
-  datacenter:
-    description:
-      - The datacenter in which to operate.
-    required: true
-  server:
-    description:
-      - The server name or ID.
-    required: true
-  name:
-    description:
-      - The name or ID of the NIC. This is only required on deletes, but not on create.
-    required: true
-  lan:
-    description:
-      - The LAN to place the NIC on. You can pass a LAN that doesn't exist and it will be created. Required on create.
-    required: true
-    default: None
-  dhcp:
-    description:
-      - Boolean value indicating if the NIC is using DHCP or not.
-    required: false
-    default: None
-    version_added: "2.4"
-  firewall_active:
-    description:
-      - Boolean value indicating if the firewall is active.
-    required: false
-    default: None
-    version_added: "2.4"
-  ips:
-    description:
-      - A list of IPs to be assigned to the NIC.
-    required: false
-    default: None
-    version_added: "2.4"
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-    version_added: "2.4"
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - "Matt Baldwin (baldwin@stackpointcloud.com)"
-    - "Ethan Devenport (@edevenport)"
-'''
-
-EXAMPLES = '''
-
-# Create a NIC
-- nic:
-    datacenter: Tardis One
-    server: node002
-    lan: 2
-    wait_timeout: 500
-    state: present
-
-# Update a NIC
-- nic:
-    datacenter: Tardis One
-    server: node002
-    name: 7341c2454f
-    lan: 1
-    ips:
-      - 158.222.103.23
-      - 158.222.103.24
-    dhcp: false
-    state: update
-
-# Remove a NIC
-- nic:
-    datacenter: Tardis One
-    server: node002
-    name: 7341c2454f
-    wait_timeout: 500
-    state: absent
-
-'''
-
+import copy
 import re
+import yaml
 
 from uuid import uuid4
 
@@ -144,6 +24,167 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'NIC'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the NIC.'],
+        'available': STATES,
+        'required': ['absent'],
+        'type': 'str',
+    },
+    'id': {
+        'description': ['The ID of the NIC.'],
+        'available': ['update'],
+        'type': 'str',
+    },
+    'datacenter': {
+        'description': ['The datacenter name or UUID in which to operate.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'server': {
+        'description': ['The server name or UUID.'],
+        'required': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+    'lan': {
+        'description': ["The LAN to place the NIC on. You can pass a LAN that doesn't exist and it will be created. Required on create."],
+        'required': ['present'],
+        'available': ['update'],
+        'type': 'str',
+    },
+    'dhcp': {
+        'description': ['Boolean value indicating if the NIC is using DHCP or not.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+        'version_added': '2.4',
+    },
+    'firewall_active': {
+        'description': ['Boolean value indicating if the firewall is active.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+        'version_added': '2.4',
+    },
+    'ips': {
+        'description': ['A list of IPs to be assigned to the NIC.'],
+        'available': ['present', 'update'],
+        'type': 'list',
+        'version_added': '2.4',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: nic
+short_description: Create, Update or Remove a NIC.
+description:
+     - This module allows you to create, update or remove a NIC.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    lan: 2
+    wait_timeout: 500
+    state: present
+  ''',
+  'update' : '''# Update a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    name: 7341c2454f
+    lan: 1
+    ips:
+      - 158.222.103.23
+      - 158.222.103.24
+    dhcp: false
+    state: update
+  ''',
+  'absent' : '''# Remove a NIC
+  - nic:
+    datacenter: Tardis One
+    server: node002
+    name: 7341c2454f
+    wait_timeout: 500
+    state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 uuid_match = re.compile(
     '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
@@ -425,52 +466,30 @@ def delete_nic(module, client):
         module.fail_json(msg="failed to remove the NIC: %s" % to_native(e))
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            datacenter=dict(type='str'),
-            server=dict(type='str'),
-            name=dict(type='str'),
-            id=dict(type='str', default=str(uuid4()).replace('-', '')[:10]),
-            lan=dict(type='int', default=None),
-            dhcp=dict(type='bool', default=None),
-            firewall_active=dict(type='bool', default=None),
-            ips=dict(type='list', default=None),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
-    if not module.params.get('datacenter'):
-        module.fail_json(msg='datacenter parameter is required')
-    if not module.params.get('server'):
-        module.fail_json(msg='server parameter is required')
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
 
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -481,37 +500,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required')
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-            try:
-                (changed) = delete_nic(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to set nic state: %s' % to_native(e))
 
-        elif state == 'present':
-            if not module.params.get('lan'):
-                module.fail_json(msg='lan parameter is required')
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-            try:
-                (nic_dict) = create_nic(module, api_client)
-                module.exit_json(**nic_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set nic state: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-        elif state == 'update':
-            try:
-                (nic_dict) = update_nic(module, api_client)
-                module.exit_json(**nic_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update nic: %s' % to_native(e))
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_nic(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_nic(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_nic(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/nic_flowlog.py
+++ b/plugins/modules/nic_flowlog.py
@@ -6,7 +6,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import copy
 import re
+import yaml
 
 HAS_SDK = True
 
@@ -22,6 +24,174 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Flowflog'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the Flowlog.'],
+        'available': STATES,
+        'required': ['present'],
+        'type': 'str',
+    },
+    'flowlog_id': {
+        'description': ['The ID of the Flowlog.'],
+        'available': ['update', 'absent'],
+        'type': 'str',
+    },
+    'datacenter_id': {
+        'description': ['The ID of the virtual datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'server_id': {
+        'description': ['The ID of the Server.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'nic_id': {
+        'description': ['The ID of the NIC.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'action': {
+        'description': ['Specifies the traffic action pattern.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'direction': {
+        'description': ['Specifies the traffic direction pattern.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'bucket': {
+        'description': ['S3 bucket name of an existing IONOS Cloud S3 bucket.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: datacenter
+short_description: Create or destroy a Ionos Cloud NIC Flowlog.
+description:
+     - This is a simple module that supports creating or removing NIC Flowlogs.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''- name: Create a nic flowlog
+  nic_flowlog:
+    name: "{{ name }}"
+    action: "ACCEPTED"
+    direction: "INGRESS"
+    bucket: "sdktest"
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+  register: flowlog_response
+  ''',
+  'update' : '''- name: Update a nic flowlog
+  nic_flowlog:
+    name: "{{ name }}"
+    action: "ALL"
+    direction: "INGRESS"
+    bucket: "sdktest"
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+    flowlog_id: "{{ flowlog_response.flowlog.id }}"
+  register: flowlog_update_response
+  ''',
+  'absent' : '''- name: Delete a nic flowlog
+  nic_flowlog:
+    datacenter_id: "{{ datacenter_response.datacenter.id }}"
+    server_id: "{{ server_response.machines[0].id }}"
+    nic_id: "{{ nic_response.nic.id }}"
+    flowlog_id: "{{ flowlog_response.flowlog.id }}"
+    name: "{{ name }}"
+    state: absent
+    wait: true
+  register: flowlog_delete_response
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
 
 uuid_match = re.compile(
     '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
@@ -221,46 +391,30 @@ def remove_flowlog(module, client):
     }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(type='str'),
-            action=dict(type='str'),
-            direction=dict(type='str'),
-            bucket=dict(type='str'),
-            datacenter_id=dict(type='str'),
-            server_id=dict(type='str'),
-            nic_id=dict(type='str'),
-            flowlog_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -271,43 +425,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-        if state == 'absent':
-            if not (module.params.get('name') or module.params.get('flowlog_id')):
-                module.fail_json(msg='name parameter or flowlog_id parameter are required deleting a flowlog.')
-            try:
-                (result) = remove_flowlog(module, api_client)
-                module.exit_json(**result)
 
-            except Exception as e:
-                module.fail_json(msg='failed to set flowlog state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        if state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new flowlog')
-            if not module.params.get('action'):
-                module.fail_json(msg='action parameter is required for a new flowlog')
-            if not module.params.get('direction'):
-                module.fail_json(msg='direction parameter is required for a new flowlog')
-            if not module.params.get('bucket'):
-                module.fail_json(msg='bucket parameter is required for a new flowlog')
 
-            try:
-                (flowlog_dict_array) = create_flowlog(module, api_client)
-                module.exit_json(**flowlog_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set flowlog state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-        elif state == 'update':
-            try:
-                (flowlog_dict_array) = update_flowlog(module, api_client)
-                module.exit_json(**flowlog_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to update the flowlog: %s' % to_native(e))
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'absent':
+                module.exit_json(**remove_flowlog(module, api_client))
+            if state == 'present':
+                module.exit_json(**create_flowlog(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_flowlog(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/pcc.py
+++ b/plugins/modules/pcc.py
@@ -1,25 +1,6 @@
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-EXAMPLES = '''
-    - name: Create pcc
-      pcc:
-        name: "{{ name }}"
-        description: "{{ description }}"
-
-    - name: Update pcc
-      pcc:
-        pcc_id: "49e73efd-e1ea-11ea-aaf5-5254001a8838"
-        name: "{{ new_name }}"
-        description: "{{ new_description }}"
-        state: update
-
-    - name: Remove pcc
-      pcc:
-        pcc_id: "2851af0b-e1ea-11ea-aaf5-5254001a8838"
-        state: absent
-'''
+import copy
+import re
+import yaml
 
 HAS_SDK = True
 try:
@@ -36,7 +17,129 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-import re
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'PCC'
+
+OPTIONS = {
+    'name': {
+        'description': ['The name of the PCC.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'pcc_id': {
+        'description': ['The ID of the PCC.'],
+        'available': ['update', 'absent'],
+        'required': ['update', 'absent'],
+        'type': 'str',
+    },
+    'description': {
+        'description': ['The description of the PCC.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: pcc
+short_description: Create or destroy a Ionos Cloud Private Cross Connect
+description:
+     - This is a simple module that supports creating or removing Private Cross Connects.
+       This module has a dependency on ionos-cloud >= 6.0.0
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create pcc
+    pcc:
+      name: "{{ name }}"
+      description: "{{ description }}"
+  ''',
+  'update' : '''
+  - name: Update pcc
+    pcc:
+      pcc_id: "49e73efd-e1ea-11ea-aaf5-5254001a8838"
+      name: "{{ new_name }}"
+      description: "{{ new_description }}"
+      state: update
+  ''',
+  'absent' : '''
+  - name: Remove pcc
+    pcc:
+      pcc_id: "2851af0b-e1ea-11ea-aaf5-5254001a8838"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_resource(resource_list, identity):
@@ -150,39 +253,30 @@ def update_pcc(module, client):
         }
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            pcc_id=dict(type='str'),
-            name=dict(type='str'),
-            description=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
 
     conf = {
         'username': username,
@@ -193,42 +287,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
+
+
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
     state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-
-        if state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for a new pcc')
-            if not module.params.get('description'):
-                module.fail_json(msg='description parameter is required for a new pcc')
-            try:
-                (pcc_dict_array) = create_pcc(module, api_client)
-                module.exit_json(**pcc_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set user state: %s' % to_native(e))
-
-        elif state == 'absent':
-            if not module.params.get('pcc_id'):
-                module.fail_json(msg='pcc_id parameter is required for deleting a pcc.')
-            try:
-                (changed) = delete_pcc(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to set pcc state: %s' % to_native(e))
-
-        elif state == 'update':
-            if not module.params.get('pcc_id'):
-                module.fail_json(msg='pcc_id parameter is required for updating a pcc.')
-            try:
-                (changed) = update_pcc(module, api_client)
-                module.exit_json(
-                    changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to set pcc state: %s' % to_native(e))
+        try:
+            if state == 'present':
+                module.exit_json(**create_pcc(module, api_client))
+            elif state == 'absent':
+                module.exit_json(**delete_pcc(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_pcc(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/postgres_backup_info.py
+++ b/plugins/modules/postgres_backup_info.py
@@ -1,6 +1,81 @@
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+import copy
+import yaml
+
+from ansible import __version__
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_native
+
+HAS_SDK = True
+try:
+    import ionoscloud_dbaas_postgres
+    from ionoscloud_dbaas_postgres import __version__ as sdk_version
+except ImportError:
+    HAS_SDK = False
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+DBAAS_POSTGRES_USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, ionoscloud_dbaas_postgres.__version__)
+DOC_DIRECTORY = 'dbaas-postgres'
+STATES = ['info']
+OBJECT_NAME = 'Postgres Cluster Backups'
+
+OPTIONS = {
+    'postgres_cluster': {
+        'description': ['The ID or name of an existing Postgres Cluster.'],
+        'available': STATES,
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'available': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: postgres_backup_info
+short_description: List Postgres Cluster backups.
+description:
+     - This is a simple module that supports listing existing Postgres Cluster backups
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud-dbaas-postgres >= 1.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
 
 EXAMPLES = '''
     - name: List Postgres Cluster Backups
@@ -13,16 +88,6 @@ EXAMPLES = '''
             var: postgres_clusters_response.result
 '''
 
-from ansible import __version__
-from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
-
-
-HAS_SDK = True
-try:
-    import ionoscloud_dbaas_postgres
-except ImportError:
-    HAS_SDK = False
 
 def _get_dbaas_cluser(resource_list, identity):
     """
@@ -36,47 +101,64 @@ def _get_dbaas_cluser(resource_list, identity):
 
     return None
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            postgres_cluster=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME']),
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True,
-            ),
-        ),
-        supports_check_mode=True,
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud_dbaas_postgres is required for this module, run `pip install ionoscloud_dbaas_postgres`')
 
+def get_module_arguments():
+    arguments = {}
+
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, ionoscloud_dbaas_postgres.__version__)
 
-    config = {
+    conf = {
         'username': username,
         'password': password,
     }
 
     if api_url is not None:
-        config['host'] = api_url
-        config['server_index'] = None
+        conf['host'] = api_url
+        conf['server_index'] = None
 
-    dbaas_postgres_api_client = ionoscloud_dbaas_postgres.ApiClient(ionoscloud_dbaas_postgres.Configuration(**config))
+    return sdk.Configuration(**conf)
 
-    dbaas_postgres_api_client.user_agent = user_agent
+
+def check_required_arguments(module, object_name):
+    for option_name, option in OPTIONS.items():
+        if 'info' in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for retrieving {object_name}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud_dbaas_postgres is required for this module, run `pip install ionoscloud_dbaas_postgres`')
+
+    dbaas_postgres_api_client = ionoscloud_dbaas_postgres.ApiClient(get_sdk_config(module, ionoscloud_dbaas_postgres))
+    dbaas_postgres_api_client.user_agent = DBAAS_POSTGRES_USER_AGENT
+
+    check_required_arguments(module, OBJECT_NAME)
 
     try:
         results = []
@@ -96,7 +178,7 @@ def main():
 
         module.exit_json(result=results)
     except Exception as e:
-            module.fail_json(msg='failed to retrieve Postgres Cluster Backups: %s' % to_native(e))
+        module.fail_json(msg='failed to retrieve {object_name}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e)))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/s3key.py
+++ b/plugins/modules/s3key.py
@@ -43,7 +43,14 @@ OPTIONS = {
         'description': ['The ID of the S3 key.'],
         'available': ['absent', 'update'],
         'required': ['absent', 'update'],
-        'type': 'str',
+        'type': 'str', 
+    },
+    'idempotency': {
+        'description': ['If a key already exists, don\'t create any more on create requests'],
+        'default': False,
+        'available': 'present',
+        'choices': [True, False],
+        'type': 'bool',
     },
     'api_url': {
         'description': ['The Ionos API base URL.'],
@@ -151,11 +158,22 @@ def _get_request_id(headers):
 def create_s3key(module, client):
     user_id = module.params.get('user_id')
     wait = module.params.get('wait')
+    do_idempotency = module.params.get('idempotency')
     wait_timeout = int(module.params.get('wait_timeout'))
 
     user_s3keys_server = ionoscloud.UserS3KeysApi(client)
+    s3key_list = user_s3keys_server.um_users_s3keys_get(user_id=user_id, depth=5)
 
     try:
+        if (do_idempotency and len(s3key_list.items) > 0):
+            s3key_response = s3key_list.items[0]
+            return {
+                'changed': False,
+                'failed': False,
+                'action': 'create',
+                's3key': s3key_response.to_dict()
+            }
+
         response = user_s3keys_server.um_users_s3keys_post_with_http_info(user_id=user_id)
         (s3key_response, _, headers) = response
 

--- a/plugins/modules/s3key.py
+++ b/plugins/modules/s3key.py
@@ -1,27 +1,6 @@
 import re
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-EXAMPLES = '''
-    - name: Create an s3key
-      s3key:
-        user_id: "{{ user_id }}"
-
-    - name: Update an s3key
-      s3key:
-        user_id: "{{ user_id }}"
-        key_id: "00ca413c94eecc56857d"
-        active: False
-        state: update
-
-    - name: Remove an s3key
-      s3key:
-        user_id: "{{ user_id }}"
-        key_id: "00ca413c94eecc56857d"
-        state: absent
-'''
+import copy
+import yaml
 
 HAS_SDK = True
 try:
@@ -37,6 +16,127 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'user-management'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'S3 Key'
+
+OPTIONS = {
+    'active': {
+        'description': ['Denotes weather the S3 key is active.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'user_id': {
+        'description': ['The ID of the user'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'key_id': {
+        'description': ['The ID of the S3 key.'],
+        'available': ['absent', 'update'],
+        'required': ['absent', 'update'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: s3key
+short_description: Create or destroy a Ionos Cloud S3Key.
+description:
+     - This is a simple module that supports creating or removing S3Keys.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''
+  - name: Create an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+  ''',
+  'update' : '''
+  - name: Update an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+      key_id: "00ca413c94eecc56857d"
+      active: False
+      state: update
+  ''',
+  'absent' : '''
+  - name: Remove an s3key
+    s3key:
+      user_id: "{{ user_id }}"
+      key_id: "00ca413c94eecc56857d"
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -158,42 +258,30 @@ def _get_resource(resource_list, identity):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            active=dict(type='bool'),
-            user_id=dict(type='str'),
-            key_id=dict(type='str'),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+def get_module_arguments():
+    arguments = {}
 
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -204,46 +292,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
+
+
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
     state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-
-        if state == 'present':
-            if not module.params.get('user_id'):
-                module.fail_json(msg='user_id parameter is required for a new s3key')
-            try:
-                (s3key_dict_array) = create_s3key(module, api_client)
-                module.exit_json(**s3key_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set user state: %s' % to_native(e))
-
-        elif state == 'absent':
-            if not module.params.get('user_id'):
-                module.fail_json(msg='user_id parameter is required for deleting an s3key.')
-            if not module.params.get('key_id'):
-                module.fail_json(msg='key_id parameter is required for deleting an s3key.')
-
-            try:
-                (changed) = delete_s3key(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to set user state: %s' % to_native(e))
-
-        elif state == 'update':
-            if not module.params.get('user_id'):
-                module.fail_json(msg='user_id parameter is required for updating an s3key.')
-            if not module.params.get('key_id'):
-                module.fail_json(msg='key_id parameter is required for updating an s3key.')
-
-            try:
-                (changed) = update_s3key(module, api_client)
-                module.exit_json(
-                    changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to set s3key state: %s' % to_native(e))
+        try:
+            if state == 'present':
+                module.exit_json(**create_s3key(module, api_client))
+            elif state == 'absent':
+                module.exit_json(**delete_s3key(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_s3key(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -4,239 +4,14 @@
 
 from __future__ import absolute_import, division, print_function
 
-__metaclass__ = type
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: server
-short_description: Create, update, destroy, start, stop, and reboot a Ionos virtual machine.
-description:
-     - Create, update, destroy, update, start, stop, and reboot a Ionos virtual machine.
-       When the virtual machine is created it can optionally wait for it to be 'running' before returning.
-version_added: "2.0"
-options:
-  auto_increment:
-    description:
-      - Whether or not to increment a single number in the name for created virtual machines.
-    default: yes
-    choices: ["yes", "no"]
-  name:
-    description:
-      - The name of the virtual machine.
-    required: true
-  image:
-    description:
-      - The image alias or ID for creating the virtual machine.
-    required: true
-  image_password:
-    description:
-      - Password set for the administrative user.
-    required: false
-    version_added: "2.2"
-  ssh_keys:
-    description:
-      - Public SSH keys allowing access to the virtual machine.
-    required: false
-    version_added: "2.2"
-  volume_availability_zone:
-    description:
-      - The storage availability zone assigned to the volume.
-    required: false
-    default: None
-    choices: [ "AUTO", "ZONE_1", "ZONE_2", "ZONE_3" ]
-    version_added: "2.3"
-  datacenter:
-    description:
-      - The datacenter to provision this virtual machine.
-    required: false
-    default: null
-  cores:
-    description:
-      - The number of CPU cores to allocate to the virtual machine.
-    required: false
-    default: 2
-  ram:
-    description:
-      - The amount of memory to allocate to the virtual machine.
-    required: false
-    default: 2048
-  cpu_family:
-    description:
-      - The CPU family type to allocate to the virtual machine.
-    required: false
-    default: AMD_OPTERON
-    choices: [ "AMD_OPTERON", "INTEL_XEON", "INTEL_SKYLAKE" ]
-    version_added: "2.2"
-  availability_zone:
-    description:
-      - The availability zone assigned to the server.
-    required: false
-    default: AUTO
-    choices: [ "AUTO", "ZONE_1", "ZONE_2" ]
-    version_added: "2.3"
-  volume_size:
-    description:
-      - The size in GB of the boot volume.
-    required: false
-    default: 10
-  bus:
-    description:
-      - The bus type for the volume.
-    required: false
-    default: VIRTIO
-    choices: [ "IDE", "VIRTIO"]
-  instance_ids:
-    description:
-      - list of instance ids, currently only used when state='absent' to remove instances.
-    required: false
-  count:
-    description:
-      - The number of virtual machines to create.
-    required: false
-    default: 1
-  location:
-    description:
-      - The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.
-    required: false
-    default: us/las
-    choices: [ "us/las", "us/ewr", "de/fra", "de/fkb", "de/txl", "gb/lhr" ]
-  assign_public_ip:
-    description:
-      - This will assign the machine to the public LAN. If no LAN exists with public Internet access it is created.
-    required: false
-    default: false
-  lan:
-    description:
-      - The ID or name of the LAN you wish to add the servers to (can be a string or a number).
-    required: false
-    default: 1
-  nat:
-    description:
-      - Boolean value indicating if the private IP address has outbound access to the public Internet.
-    required: false
-    default: false
-    version_added: "2.3"
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-    version_added: "2.4"
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the instance to be in state 'running' before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  remove_boot_volume:
-    description:
-      - remove the bootVolume of the virtual machine you're destroying.
-    required: false
-    default: "yes"
-    choices: ["yes", "no"]
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: [ "running", "stopped", "absent", "present", "update" ]
-
-requirements:
-    - "python >= 2.6"
-    - "ionos-cloud >= 5.2.0"
-author:
-    - "Matt Baldwin (baldwin@stackpointcloud.com)"
-    - "Ethan Devenport (@edevenport)"
-'''
-
-EXAMPLES = '''
-
-# Provisioning example. This will create three servers and enumerate their names.
-
-- server:
-    datacenter: Tardis One
-    name: web%02d.stackpointcloud.com
-    cores: 4
-    ram: 2048
-    volume_size: 50
-    cpu_family: INTEL_XEON
-    image: ubuntu:latest
-    location: us/las
-    count: 3
-    assign_public_ip: true
-
-# Update Virtual machines
-
-- server:
-    datacenter: Tardis One
-    instance_ids:
-      - web001.stackpointcloud.com
-      - web002.stackpointcloud.com
-    cores: 4
-    ram: 4096
-    cpu_family: INTEL_XEON
-    availability_zone: ZONE_1
-    state: update
-
-# Removing Virtual machines
-
-- server:
-    datacenter: Tardis One
-    instance_ids:
-      - 'web001.stackpointcloud.com'
-      - 'web002.stackpointcloud.com'
-      - 'web003.stackpointcloud.com'
-    wait_timeout: 500
-    state: absent
-
-# Starting Virtual Machines.
-
-- server:
-    datacenter: Tardis One
-    instance_ids:
-      - 'web001.stackpointcloud.com'
-      - 'web002.stackpointcloud.com'
-      - 'web003.stackpointcloud.com'
-    wait_timeout: 500
-    state: running
-
-# Stopping Virtual Machines
-
-- server:
-    datacenter: Tardis One
-    instance_ids:
-      - 'web001.stackpointcloud.com'
-      - 'web002.stackpointcloud.com'
-      - 'web003.stackpointcloud.com'
-    wait_timeout: 500
-    state: stopped
-
-'''
-
+import copy
 import re
 import traceback
+import yaml
 
 from uuid import (uuid4, UUID)
 
-HAS_PB_SDK = True
+HAS_SDK = True
 
 try:
     import ionoscloud
@@ -247,45 +22,337 @@ try:
     from ionoscloud.rest import ApiException
     from ionoscloud import ApiClient
 except ImportError:
-    HAS_PB_SDK = False
+    HAS_SDK = False
 
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_native
 
-LOCATIONS = ['us/las',
-             'us/ewr',
-             'de/fra',
-             'de/fkb',
-             'de/txl',
-             'gb/lhr'
-             ]
+__metaclass__ = type
 
-CPU_FAMILIES = ['AMD_OPTERON',
-                'INTEL_XEON',
-                'INTEL_SKYLAKE']
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['running', 'stopped', 'resume', 'suspend', 'absent', 'present', 'update']
+OBJECT_NAME = 'Server'
 
-DISK_TYPES = ['HDD',
-              'SSD',
-              'SSD Standard',
-              'SSD Premium',
-              'DAS'
-              ]
+AVAILABILITY_ZONES = [
+    'AUTO',
+    'ZONE_1',
+    'ZONE_2',
+    'ZONE_3',
+]
 
-BUS_TYPES = ['VIRTIO',
-             'IDE']
+OPTIONS = {
+    'name': {
+        'description': ['The name of the virtual machine.'],
+        'required': ['present'],
+        'available': ['present', 'update', 'absent'],
+        'type': 'str',
+    },
+    'auto_increment': {
+        'description': ['Whether or not to increment a single number in the name for created virtual machines.'],
+        'available': ['present'],
+        'choices': [True, False],
+        'default': True,
+        'type': 'bool',
+    },
+    'assign_public_ip': {
+        'description': ['This will assign the machine to the public LAN. If no LAN exists with public Internet access it is created.'],
+        'available': ['present'],
+        'choices': [True, False],
+        'default': False,
+        'type': 'bool',
+    },
+    'image': {
+        'description': ['The image alias or ID for creating the virtual machine.'],
+        'required': ['present'],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'image_password': {
+        'description': ['Password set for the administrative user.'],
+        'available': ['present'],
+        'version_added': '2.2',
+        'no_log': True,
+        'type': 'str',
+    },
+    'ssh_keys': {
+        'description': ['Public SSH keys allowing access to the virtual machine.'],
+        'available': ['present'],
+        'version_added': '2.2',
+        'default': [],
+        'type': 'list',
+    },
+    'volume_availability_zone': {
+        'description': ['The storage availability zone assigned to the volume.'],
+        'available': ['present'],
+        'choices': AVAILABILITY_ZONES,
+        'type': 'str',
+        'version_added': '2.3',
+    },
+    'datacenter': {
+        'description': ['The datacenter to provision this virtual machine.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'cores': {
+        'description': ['The number of CPU cores to allocate to the virtual machine.'],
+        'available': ['present', 'update'],
+        'default': 2,
+        'type': 'int',
+    },
+    'ram': {
+        'description': ['The amount of memory to allocate to the virtual machine.'],
+        'available': ['present', 'update'],
+        'default': 2048,
+        'type': 'int',
+    },
+    'cpu_family': {
+        'description': ['The amount of memory to allocate to the virtual machine.'],
+        'available': ['present'],
+        'choices': ['AMD_OPTERON', 'INTEL_XEON', 'INTEL_SKYLAKE'],
+        'default': 'AMD_OPTERON',
+        'type': 'str',
+        'version_added': '2.2',
+    },
+    'availability_zone': {
+        'description': ['The availability zone assigned to the server.'],
+        'available': ['present'],
+        'choices': AVAILABILITY_ZONES,
+        'default': 'AUTO',
+        'type': 'str',
+        'version_added': '2.3',
+    },
+    'volume_size': {
+        'description': ['The size in GB of the boot volume.'],
+        'available': ['present'],
+        'default': 10,
+        'type': 'int',
+    },
+    'bus': {
+        'description': ['The bus type for the volume.'],
+        'available': ['present'],
+        'choices': ['IDE', 'VIRTIO'],
+        'default': 'VIRTIO',
+        'type': 'str',
+    },
+    'instance_ids': {
+        'description': ["list of instance ids, currently only used when state='absent' to remove instances."],
+        'available': ['present'],
+        'default': [],
+        'type': 'list',
+    },
+    'count': {
+        'description': ['The number of virtual machines to create.'],
+        'available': ['present'],
+        'default': 1,
+        'type': 'int',
+    },
+    'location': {
+        'description': ['The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.'],
+        'available': ['present'],
+        'choices': ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr'],
+        'default': 'us/las',
+        'type': 'str',
+    },
+    'lan': {
+        'description': ['The ID or name of the LAN you wish to add the servers to (can be a string or a number).'],
+        'available': ['present'],
+        'default': '1',
+        'type': 'str',
+    },
+    'lan': {
+        'description': ['The ID or name of the LAN you wish to add the servers to (can be a string or a number).'],
+        'available': ['present'],
+        'type': 'raw',
+    },
+    'nat': {
+        'description': ['Boolean value indicating if the private IP address has outbound access to the public Internet.'],
+        'available': ['present'],
+        'choices': [True, False],
+        'default': False,
+        'type': 'bool',
+        'version_added': '2.3',
+    },
+    'remove_boot_volume': {
+        'description': ["Remove the bootVolume of the virtual machine you're destroying."],
+        'available': ['present'],
+        'choices': [True, False],
+        'default': True,
+        'type': 'bool',
+    },
+    'disk_type': {
+        'description': ['The disk type for the volume.'],
+        'available': ['present'],
+        'choices': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS'],
+        'default': 'HDD',
+        'type': 'str',
+    },
+    'nic_ips': {
+        'description': ['The list of IPS for the NIC.'],
+        'available': ['present'],
+        'type': 'list',
+        'elements': 'str',
+    },
+    'template_uuid': {
+        'description': ['The template used when crating a CUBE server.'],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'boot_volume': {
+        'description': ['The volume used for boot.'],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'boot_cdrom': {
+        'description': ['The CDROM used for boot.'],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'type': {
+        'description': ['The type of the virtual machine.'],
+        'available': ['present'],
+        'choices': ['ENTERPRISE', 'CUBE'],
+        'default': 'ENTERPRISE',
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
 
-AVAILABILITY_ZONES = ['AUTO',
-                      'ZONE_1',
-                      'ZONE_2',
-                      'ZONE_3']
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
 
-SERVER_TYPES = ['ENTERPRISE',
-                'CUBE']
+DOCUMENTATION = '''
+---
+module: server
+short_description: Create, update, destroy, start, stop, and reboot a Ionos virtual machine.
+description:
+     - Create, update, destroy, update, start, stop, and reboot a Ionos virtual machine.
+       When the virtual machine is created it can optionally wait for it to be 'running' before returning.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionos-cloud >= 5.2.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+EXAMPLE_PER_STATE = {
+  'present' : '''# Provisioning example. This will create three servers and enumerate their names.
+    - server:
+        datacenter: Tardis One
+        name: web%02d.stackpointcloud.com
+        cores: 4
+        ram: 2048
+        volume_size: 50
+        cpu_family: INTEL_XEON
+        image: ubuntu:latest
+        location: us/las
+        count: 3
+        assign_public_ip: true
+  ''',
+  'update' : '''# Update Virtual machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - web001.stackpointcloud.com
+        - web002.stackpointcloud.com
+        cores: 4
+        ram: 4096
+        cpu_family: INTEL_XEON
+        availability_zone: ZONE_1
+        state: update
+  ''',
+  'absent' : '''# Removing Virtual machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: absent
+  ''',
+  'running' : '''# Starting Virtual Machines.
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: running
+  ''',
+  'stopped' : '''# Stopping Virtual Machines
+    - server:
+        datacenter: Tardis One
+        instance_ids:
+        - 'web001.stackpointcloud.com'
+        - 'web002.stackpointcloud.com'
+        - 'web003.stackpointcloud.com'
+        wait_timeout: 500
+        state: stopped
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_request_id(headers):
@@ -909,69 +976,30 @@ def _get_instance(instance_list, identity):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            datacenter=dict(type='str'),
-            name=dict(type='str'),
-            image=dict(type='str'),
-            cores=dict(type='int', default=2),
-            ram=dict(type='int', default=2048),
-            cpu_family=dict(type='str', choices=CPU_FAMILIES, default='AMD_OPTERON'),
-            volume_size=dict(type='int', default=10),
-            disk_type=dict(type='str', choices=DISK_TYPES, default='HDD'),
-            availability_zone=dict(type='str', choices=AVAILABILITY_ZONES, default='AUTO'),
-            volume_availability_zone=dict(type='str', choices=AVAILABILITY_ZONES, default=None),
-            image_password=dict(type='str', default=None, no_log=True),
-            ssh_keys=dict(type='list', default=[]),
-            bus=dict(type='str', choices=BUS_TYPES, default='VIRTIO'),
-            nic_ips=dict(type='list', elements='str'),
-            lan=dict(type='raw', required=False),
-            nat=dict(type='bool', default=None),
-            template_uuid=dict(type='str'),
-            boot_volume=dict(type='str'),
-            boot_cdrom=dict(type='str'),
-            type=dict(type='str', choices=SERVER_TYPES, default='ENTERPRISE'),
-            count=dict(type='int', default=1),
-            auto_increment=dict(type='bool', default=True),
-            instance_ids=dict(type='list', default=[]),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            location=dict(type='str', choices=LOCATIONS, default='us/las'),
-            assign_public_ip=dict(type='bool', default=False),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            remove_boot_volume=dict(type='bool', default=True),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if module.params.get('lan') is not None and not (
-            isinstance(module.params.get('lan'), str) or isinstance(module.params.get('lan'), int)):
-        module.fail_json(msg='lan should either be a string or a number')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
-    if not HAS_PB_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
 
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -982,65 +1010,53 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return ionoscloud.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required for running or stopping machines.')
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-            try:
-                (result) = remove_virtual_machine(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set instance state: %s' % to_native(e),
-                                 exception=traceback.format_exc())
 
-        elif state in ('running', 'stopped'):
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required for running or stopping machines.')
-            try:
-                (result) = startstop_machine(module, api_client, state)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set instance state: %s' % to_native(e),
-                                 exception=traceback.format_exc())
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-        elif state in ('resume', 'suspend'):
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required for resuming or suspending machines.')
-            try:
-                (result) = resume_suspend_machine(module, api_client, state)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set instance state: %s' % to_native(e),
-                                 exception=traceback.format_exc())
+    if (
+        module.params.get('lan') is not None 
+        and not (isinstance(module.params.get('lan'), str) or isinstance(module.params.get('lan'), int))
+    ):
+        module.fail_json(msg='lan should either be a string or a number')
 
-        elif state == 'present':
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for new instance')
-            if not module.params.get('image'):
-                module.fail_json(msg='image parameter is required for new instance')
+    state = module.params.get('state')
+    check_required_arguments(module, state, OBJECT_NAME)
 
-            if module.check_mode:
-                module.exit_json(changed=True)
+    with ApiClient(get_sdk_config(module)) as api_client:
+        api_client.user_agent = USER_AGENT
 
-            try:
-                (machine_dict_array) = create_virtual_machine(module, api_client)
-                module.exit_json(**machine_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set instance state: %s' % to_native(e),
-                                 exception=traceback.format_exc())
-
-        elif state == 'update':
-            try:
-                (machine_dict_array) = update_server(module, api_client)
-                module.exit_json(**machine_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to update server: %s' % to_native(e), exception=traceback.format_exc())
-
+        try:
+            if state == 'absent':
+                module.exit_json(**remove_virtual_machine(module, api_client))
+            elif state in ('running', 'stopped'):
+                module.exit_json(**startstop_machine(module, api_client, state))
+            elif state in ('resume', 'suspend'):
+                module.exit_json(**resume_suspend_machine(module, api_client, state))
+            elif state == 'present':
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                module.exit_json(**create_virtual_machine(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_server(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/share.py
+++ b/plugins/modules/share.py
@@ -4,110 +4,14 @@
 
 from __future__ import absolute_import, division, print_function
 
+import yaml
+
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: share
-short_description: Add, update or remove shares.
-description:
-     - This module allows you to add, update or remove resource shares.
-version_added: "2.4"
-options:
-  group:
-    description:
-      - The name or ID of the group.
-    required: true
-  resource_ids:
-    description:
-      - A list of resource IDs to add, update or remove as shares.
-    required: true
-  edit_privilege:
-    description:
-      - Boolean value indicating that the group has permission to edit privileges on the resource.
-    required: false
-    default: None
-  share_privilege:
-    description:
-      - Boolean value indicating that the group has permission to share the resource.
-    required: false
-    default: None
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - Nurfet Becirevic (@nurfet-becirevic)
-    - Ethan Devenport (@edevenport)
-'''
-
-EXAMPLES = '''
-# Create shares
-- name: Create share
-  share:
-    group: Demo
-    edit_privilege: true
-    share_privilege: true
-    resource_ids:
-      - b50ba74e-b585-44d6-9b6e-68941b2ce98e
-      - ba7efccb-a761-11e7-90a7-525400f64d8d
-    state: present
-
-# Update shares
-- name: Update shares
-  share:
-    group: Demo
-    edit_privilege: false
-    resource_ids:
-      - b50ba74e-b585-44d6-9b6e-68941b2ce98e
-    state: update
-
-# Remove shares
-- name: Remove shares
-  share:
-    group: Demo
-    resource_ids:
-      - b50ba74e-b585-44d6-9b6e-68941b2ce98e
-      - ba7efccb-a761-11e7-90a7-525400f64d8d
-    state: absent
-'''
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -123,6 +27,141 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'user-management'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Share'
+
+OPTIONS = {
+    'edit_privilege': {
+        'description': ['Boolean value indicating that the group has permission to edit privileges on the resource.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'share_privilege': {
+        'description': ['Boolean value indicating that the group has permission to share the resource.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'group': {
+        'description': ['The name or ID of the group.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'resource_ids': {
+        'description': ['A list of resource IDs to add, update or remove as shares.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'list',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: share
+short_description: Add, update or remove shares.
+description:
+     - This module allows you to add, update or remove resource shares.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create shares
+  - name: Create share
+    share:
+      group: Demo
+      edit_privilege: true
+      share_privilege: true
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+        - ba7efccb-a761-11e7-90a7-525400f64d8d
+      state: present
+  ''',
+  'update' : '''# Update shares
+  - name: Update shares
+    share:
+      group: Demo
+      edit_privilege: false
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+      state: update
+  ''',
+  'absent' : '''# Remove shares
+  - name: Remove shares
+    share:
+      group: Demo
+      resource_ids:
+        - b50ba74e-b585-44d6-9b6e-68941b2ce98e
+        - ba7efccb-a761-11e7-90a7-525400f64d8d
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -321,43 +360,30 @@ def _get_resource_id(resource_list, identity, module, resource_type):
     module.fail_json(msg='%s \'%s\' could not be found.' % (resource_type, identity))
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            group=dict(type='str', required=True),
-            edit_privilege=dict(type='bool', default=None),
-            share_privilege=dict(type='bool', default=None),
-            resource_ids=dict(type='list', required=True),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -368,31 +394,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            try:
-                (result) = delete_shares(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set state of the shares: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'present':
-            try:
-                (share_dict) = create_shares(module, api_client)
-                module.exit_json(**share_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set state of the shares: %s' % to_native(e))
 
-        elif state == 'update':
-            try:
-                (share_dict) = update_shares(module, api_client)
-                module.exit_json(**share_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update share: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
+
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_shares(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_shares(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_shares(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -4,151 +4,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-__metaclass__ = type
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: snapshot
-short_description: Create, restore, update or remove a snapshot.
-description:
-     - This module allows you to create or remove a snapshot.
-version_added: "2.4"
-options:
-  datacenter:
-    description:
-      - The datacenter in which the volumes reside.
-    required: true
-  volume:
-    description:
-      - The name or UUID of the volume.
-    required: true
-  name:
-    description:
-      - The name of the snapshot.
-    required: false
-  description:
-    description:
-      - The description of the snapshot.
-    required: false
-  cpu_hot_plug:
-    description:
-      - Boolean value indicating the volume is capable of CPU hot plug (no reboot required).
-    required: false
-    default: None
-  cpu_hot_unplug:
-    description:
-      - Boolean value indicating the volume is capable of CPU hot unplug (no reboot required).
-    required: false
-    default: None
-  ram_hot_plug:
-    description:
-      - Boolean value indicating the volume is capable of memory hot plug (no reboot required).
-    required: false
-    default: None
-  ram_hot_unplug:
-    description:
-      - Boolean value indicating the volume is capable of memory hot unplug (no reboot required).
-    required: false
-    default: None
-  nic_hot_plug:
-    description:
-      - Boolean value indicating the volume is capable of NIC hot plug (no reboot required).
-    required: false
-    default: None
-  nic_hot_unplug:
-    description:
-      - Boolean value indicating the volume is capable of NIC hot unplug (no reboot required).
-    required: false
-    default: None
-  disc_virtio_hot_plug:
-    description:
-      - Boolean value indicating the volume is capable of VirtIO drive hot plug (no reboot required).
-    required: false
-    default: None
-  disc_virtio_hot_unplug:
-    description:
-      - Boolean value indicating the volume is capable of VirtIO drive hot unplug (no reboot required).
-    required: false
-    default: None
-  disc_scsi_hot_plug:
-    description:
-      - Boolean value indicating the volume is capable of SCSI drive hot plug (no reboot required).
-    required: false
-    default: None
-  disc_scsi_hot_unplug:
-    description:
-      - Boolean value indicating the volume is capable of SCSI drive hot unplug (no reboot required).
-    required: false
-    default: None
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "restore", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - Nurfet Becirevic (@nurfet-becirevic)
-    - Ethan Devenport (@edevenport)
-'''
-
-EXAMPLES = '''
-# Create a snapshot
-- name: Create snapshot
-  snapshot:
-    datacenter: production DC
-    volume: master
-    name: boot volume image
-    state: present
-
-# Restore a snapshot
-- name: Restore snapshot
-  snapshot:
-    datacenter: production DC
-    volume: slave
-    name: boot volume image
-    state: restore
-
-# Remove a snapshot
-- name: Remove snapshot
-  snapshot:
-    name: master-Snapshot-11/30/2017
-    state: absent
-'''
-
+import copy
 import re
+import yaml
 
 HAS_SDK = True
 
@@ -165,11 +23,201 @@ from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
 
-LICENCE_TYPES = ['LINUX',
-                 'WINDOWS',
-                 'UNKNOWN',
-                 'OTHER',
-                 'WINDOWS2016']
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update', 'restore']
+OBJECT_NAME = 'Snapshot'
+
+LICENCE_TYPES = ['LINUX', 'WINDOWS', 'UNKNOWN', 'OTHER', 'WINDOWS2016']
+OPTIONS = {
+    'datacenter': {
+        'description': ['The datacenter in which the volumes reside.'],
+        'available': ['present', 'restore'],
+        'required': ['present', 'restore'],
+        'type': 'str',
+    },
+    'volume': {
+        'description': ['The name or UUID of the volume.'],
+        'available': ['present', 'restore'],
+        'required': ['present', 'restore'],
+        'type': 'str',
+    },
+    'name': {
+        'description': ['The name of the snapshot.'],
+        'available': STATES,
+        'required': ['restore', 'update', 'absent'],
+        'type': 'str',
+    },
+    'description': {
+        'description': ['The description of the snapshot.'],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'licence_type': {
+        'description': ['The license type used'],
+        'choices': ['LINUX', 'WINDOWS', 'UNKNOWN', 'OTHER', 'WINDOWS2016'],
+        'available': ['update'],
+        'type': 'str',
+    },
+    'cpu_hot_plug': {
+        'description': ['Hot-plug capable CPU (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'cpu_hot_unplug': {
+        'description': ['Hot-unplug capable CPU (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'ram_hot_plug': {
+        'description': ['Hot-plug capable RAM (no reboot required)'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'ram_hot_unplug': {
+        'description': ['Hot-unplug capable RAM (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'nic_hot_plug': {
+        'description': ['Hot-plug capable NIC (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'nic_hot_unplug': {
+        'description': ['Hot-unplug capable NIC (no reboot required)'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_scsi_hot_plug': {
+        'description': ['Hot-plug capable SCSI drive (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_scsi_hot_unplug': {
+        'description': ['Hot-unplug capable SCSI drive (no reboot required). Not supported with Windows VMs.'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_virtio_hot_plug': {
+        'description': ['Hot-plug capable Virt-IO drive (no reboot required).'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'disc_virtio_hot_unplug': {
+        'description': ['Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs.'],
+        'available': ['update'],
+        'type': 'bool',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: snapshot
+short_description: Create, restore, update or remove a snapshot.
+description:
+     - This module allows you to create or remove a snapshot.
+version_added: "2.4"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a snapshot
+  - name: Create snapshot
+    snapshot:
+      datacenter: production DC
+      volume: master
+      name: boot volume image
+      state: present
+
+  ''',
+  'update' : '''# Update a snapshot
+  - name: Update snapshot
+    snapshot:
+      name: "boot volume image"
+      description: Ansible test snapshot - RENAME
+      state: update
+  ''',
+  'restore' : '''# Restore a snapshot
+  - name: Restore snapshot
+    snapshot:
+      datacenter: production DC
+      volume: slave
+      name: boot volume image
+      state: restore
+  ''',
+  'absent' : '''# Remove a snapshot
+  - name: Remove snapshot
+    snapshot:
+      name: master-Snapshot-11/30/2017
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -464,55 +512,30 @@ def _get_resource(resource_list, identity):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            datacenter=dict(type='str'),
-            volume=dict(type='str'),
-            name=dict(type='str', default=''),
-            description=dict(type='str', default=''),
-            licence_type=dict(type='str', choices=LICENCE_TYPES, default=None),
-            cpu_hot_plug=dict(type='bool', default=None),
-            cpu_hot_unplug=dict(type='bool', default=None),
-            ram_hot_plug=dict(type='bool', default=None),
-            ram_hot_unplug=dict(type='bool', default=None),
-            nic_hot_plug=dict(type='bool', default=None),
-            nic_hot_unplug=dict(type='bool', default=None),
-            disc_virtio_hot_plug=dict(type='bool', default=None),
-            disc_virtio_hot_unplug=dict(type='bool', default=None),
-            disc_scsi_hot_plug=dict(type='bool', default=None),
-            disc_scsi_hot_unplug=dict(type='bool', default=None),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -523,49 +546,43 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
 
-        if state == 'absent':
-            try:
-                (changed) = delete_snapshot(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to set snapshot state: %s' % to_native(e))
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
 
-        elif state == 'present':
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required')
-            if not module.params.get('volume'):
-                module.fail_json(msg='volume parameter is required')
 
-            try:
-                (snapshot_dict) = create_snapshot(module, api_client)
-                module.exit_json(**snapshot_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set snapshot state: %s' % to_native(e))
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
 
-        elif state == 'restore':
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required')
-            if not module.params.get('volume'):
-                module.fail_json(msg='volume parameter is required')
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
-            try:
-                (changed) = restore_snapshot(module, api_client)
-                module.exit_json(changed=changed)
-            except Exception as e:
-                module.fail_json(msg='failed to restore snapshot: %s' % to_native(e))
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-        elif state == 'update':
-            try:
-                (snapshot_dict) = update_snapshot(module, api_client)
-                module.exit_json(**snapshot_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update snapshot: %s' % to_native(e))
-
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_snapshot(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_snapshot(module, api_client))
+            elif state == 'restore':
+                module.exit_json(**restore_snapshot(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_snapshot(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -6,126 +6,10 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: user
-short_description: Create, update or remove a user.
-description:
-     - This module allows you to create, update or remove a user.
-version_added: "2.4"
-options:
-  firstname:
-    description:
-      - The user's first name.
-    required: true
-    default: None
-  lastname:
-    description:
-      - The user's last name.
-    required: true
-    default: None
-  email:
-    description:
-      - The user's email.
-    required: true
-    default: None
-  user_password:
-    description:
-      - A password for the user.
-    required: true
-    default: None
-  administrator:
-    description:
-      - Boolean value indicating if the user has administrative rights.
-    required: false
-    default: None
-  force_sec_auth:
-    description:
-      - Boolean value indicating if secure (two-factor) authentication should be forced for the user.
-    required: false
-    default: None
-  groups:
-    description:
-      - A list of group IDs or names where the user (non-administrator) is to be added.
-        Set to empty list ([]) to remove the user from all groups.
-    required: false
-    default: None
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the operation to complete before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - Nurfet Becirevic (@nurfet-becirevic)
-    - Ethan Devenport (@edevenport)
-'''
-
-EXAMPLES = '''
-# Create a user
-- name: Create user
-  user:
-    firstname: John
-    lastname: Doe
-    email: john.doe@example.com
-    user_password: secretpassword123
-    administrator: true
-    state: present
-
-# Update a user
-- name: Update user
-  user:
-    firstname: John II
-    lastname: Doe
-    email: john.doe@example.com
-    administrator: false
-    force_sec_auth: false
-    groups:
-      - Developers
-      - Testers
-    state: update
-
-# Remove a user
-- name: Remove user
-  user:
-    email: john.doe@example.com
-    state: absent
-'''
 
 import re
+import copy
+import yaml
 
 HAS_SDK = True
 
@@ -141,6 +25,172 @@ except ImportError:
 from ansible import __version__
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'user-management'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'User'
+
+OPTIONS = {
+    'firstname': {
+        'description': ["The user's first name."],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'lastname': {
+        'description': ["The user's last name."],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+    },
+    'email': {
+        'description': ["The user's email"],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'user_password': {
+        'description': ['A password for the user.'],
+        'available': ['present', 'update'],
+        'required': ['present'],
+        'type': 'str',
+        'no_log': True,
+    },
+    'administrator': {
+        'description': ['Boolean value indicating if the user has administrative rights.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'force_sec_auth': {
+        'description': ['Boolean value indicating if secure (two-factor) authentication should be forced for the user.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'groups': {
+        'description': [
+            'A list of group IDs or names where the user (non-administrator) is to be added.'
+            'Set to empty list ([]) to remove the user from all groups.',
+        ],
+        'available': ['present', 'update'],
+        'type': 'list',
+    },
+    'sec_auth_active': {
+        'description': ['Indicates if secure authentication is active for the user.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    's3_canonical_user_id': {
+        'description': ['Canonical (S3) ID of the user for a given identity.'],
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: user
+short_description: Create, update or remove a user.
+description:
+     - This module allows you to create, update or remove a user.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create a user
+  - name: Create user
+    user:
+      firstname: John
+      lastname: Doe
+      email: john.doe@example.com
+      user_password: secretpassword123
+      administrator: true
+      state: present
+  ''',
+  'update' : '''# Update a user
+  - name: Update user
+    user:
+      firstname: John II
+      lastname: Doe
+      email: john.doe@example.com
+      administrator: false
+      force_sec_auth: false
+      groups:
+        - Developers
+        - Testers
+      state: update
+  ''',
+  'absent' : '''# Remove a user
+  - name: Remove user
+    user:
+      email: john.doe@example.com
+      state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
 
 
 def _get_request_id(headers):
@@ -163,15 +213,9 @@ def create_user(module, client, api_client):
         The user instance
     """
     firstname = module.params.get('firstname')
-    if not firstname:
-        module.fail_json(msg='firstname parameter is required')
     lastname = module.params.get('lastname')
-    if not lastname:
-        module.fail_json(msg='lastname parameter is required')
     email = module.params.get('email')
     user_password = module.params.get('user_password')
-    if not user_password:
-        module.fail_json(msg='user_password parameter is required')
     administrator = module.params.get('administrator')
     force_sec_auth = module.params.get('force_sec_auth')
     wait = module.params.get('wait')
@@ -379,49 +423,30 @@ def _get_resource_id(resource_list, identity, module, resource_type):
     module.fail_json(msg='%s \'%s\' could not be found.' % (resource_type, identity))
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            firstname=dict(type='str'),
-            lastname=dict(type='str'),
-            email=dict(type='str', required=True),
-            user_password=dict(type='str', default=None, no_log=True),
-            administrator=dict(type='bool', default=None),
-            force_sec_auth=dict(type='bool', default=None),
-            groups=dict(type='list', default=None),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            sec_auth_active=dict(type='bool', default=False),
-            s3_canonical_user_id=dict(type='str'),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
-
-    state = module.params.get('state')
 
     conf = {
         'username': username,
@@ -432,32 +457,42 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
+
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
         api_instance = ionoscloud.UserManagementApi(api_client)
 
-        if state == 'absent':
-            try:
-                (result) = delete_user(module, api_instance)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set user state: %s' % to_native(e))
-
-        elif state == 'present':
-            try:
-                (user_dict) = create_user(module, api_instance, api_client)
-                module.exit_json(**user_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to set user state: %s' % to_native(e))
-
-        elif state == 'update':
-            try:
-                (user_dict) = update_user(module, api_instance, api_client)
-                module.exit_json(**user_dict)
-            except Exception as e:
-                module.fail_json(msg='failed to update user: %s' % to_native(e))
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_user(module, api_instance))
+            elif state == 'present':
+                module.exit_json(**create_user(module, api_instance, api_client))
+            elif state == 'update':
+                module.exit_json(**update_user(module, api_instance, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -3,164 +3,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
-DOCUMENTATION = '''
----
-module: volume
-short_description: Create, update or destroy a volume.
-description:
-     - Allows you to create, update or remove a volume from a Ionos datacenter.
-version_added: "2.0"
-options:
-  datacenter:
-    description:
-      - The datacenter in which to create the volumes.
-    required: true
-  name:
-    description:
-      - The name of the volumes. You can enumerate the names using auto_increment.
-    required: true
-  size:
-    description:
-      - The size of the volume.
-    required: false
-    default: 10
-  bus:
-    description:
-      - The bus type.
-    required: false
-    default: VIRTIO
-    choices: [ "IDE", "VIRTIO"]
-  image:
-    description:
-      - The image alias or ID for the volume. This can also be a snapshot image ID.
-    required: true
-  image_password:
-    description:
-      - Password set for the administrative user.
-    required: false
-    version_added: "2.2"
-  ssh_keys:
-    description:
-      - Public SSH keys allowing access to the virtual machine.
-    required: false
-    version_added: "2.2"
-  disk_type:
-    description:
-      - The disk type of the volume.
-    required: false
-    default: HDD
-    choices: [ "HDD", "SSD" ]
-  licence_type:
-    description:
-      - The licence type for the volume. This is used when the image is non-standard.
-    required: false
-    default: UNKNOWN
-    choices: ["LINUX", "WINDOWS", "UNKNOWN" , "OTHER", "WINDOWS2016"]
-  availability_zone:
-    description:
-      - The storage availability zone assigned to the volume.
-    required: false
-    default: None
-    choices: [ "AUTO", "ZONE_1", "ZONE_2", "ZONE_3" ]
-    version_added: "2.3"
-  count:
-    description:
-      - The number of volumes you wish to create.
-    required: false
-    default: 1
-  auto_increment:
-    description:
-      - Whether or not to increment a single number in the name for created virtual machines.
-    default: yes
-    choices: ["yes", "no"]
-  instance_ids:
-    description:
-      - list of instance ids, currently only used when state='absent' to remove instances.
-    required: false
-  api_url:
-    description:
-      - The Ionos API base URL.
-    required: false
-    default: null
-    version_added: "2.4"
-  username:
-    description:
-      - The Ionos username. Overrides the IONOS_USERNAME environment variable.
-    required: false
-    aliases: subscription_user
-  password:
-    description:
-      - The Ionos password. Overrides the IONOS_PASSWORD environment variable.
-    required: false
-    aliases: subscription_password
-  wait:
-    description:
-      - wait for the datacenter to be created before returning
-    required: false
-    default: "yes"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - how long before wait gives up, in seconds
-    default: 600
-  state:
-    description:
-      - Indicate desired state of the resource
-    required: false
-    default: "present"
-    choices: ["present", "absent", "update"]
-
-requirements:
-    - "python >= 2.6"
-    - "ionoscloud >= 5.0.0"
-author:
-    - "Matt Baldwin (baldwin@stackpointcloud.com)"
-    - "Ethan Devenport (@edevenport)"
-'''
-
-EXAMPLES = '''
-
-# Create Multiple Volumes
-
-- volume:
-    datacenter: Tardis One
-    name: vol%02d
-    count: 5
-    auto_increment: yes
-    wait_timeout: 500
-    state: present
-
-# Update Volumes
-
-- volume:
-    datacenter: Tardis One
-    instance_ids:
-      - 'vol01'
-      - 'vol02'
-    size: 50
-    bus: IDE
-    wait_timeout: 500
-    state: update
-
-# Remove Volumes
-
-- volume:
-    datacenter: Tardis One
-    instance_ids:
-      - 'vol01'
-      - 'vol02'
-    wait_timeout: 500
-    state: absent
-
-'''
-
+import copy
+import yaml
 import re
 import traceback
 
@@ -182,27 +26,260 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_native
 
-DISK_TYPES = ['HDD',
-              'SSD',
-              'SSD Premium',
-              'SSD Standard']
 
-BUS_TYPES = ['VIRTIO',
-             'IDE']
+__metaclass__ = type
 
-AVAILABILITY_ZONES = ['AUTO',
-                      'ZONE_1',
-                      'ZONE_2',
-                      'ZONE_3']
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['present', 'absent', 'update']
+OBJECT_NAME = 'Volume'
 
-LICENCE_TYPES = ['LINUX',
-                 'WINDOWS',
-                 'UNKNOWN',
-                 'OTHER',
-                 'WINDOWS2016']
+OPTIONS = {
+    'datacenter': {
+        'description': ['The datacenter in which to create the volumes.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'server': {
+        'description': ['The server to which to attach the volume.'],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'name': {
+        'description': ['The name of the volumes. You can enumerate the names using auto_increment.'],
+        'required': ['present'],
+        'available': STATES,
+        'type': 'str',
+    },
+    'size': {
+        'description': ['The size of the volume.'],
+        'available': ['update', 'present'],
+        'default': 10,
+        'type': 'int',
+    },
+    'bus': {
+        'description': ['The bus type.'],
+        'choices': ['VIRTIO', 'IDE'],
+        'default': 'VIRTIO',
+        'available': ['present', 'update'],
+        'type': 'str',
+    },
+    'image': {
+        'description': ['The image alias or ID for the volume. This can also be a snapshot image ID.'],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'image_password': {
+        'description': ['Password set for the administrative user.'],
+        'available': ['present'],
+        'type': 'str',
+        'no_log': True,
+        'version_added': '2.2',
+    },
+    'ssh_keys': {
+        'description': ['Public SSH keys allowing access to the virtual machine.'],
+        'available': ['present'],
+        'type': 'list',
+        'default': [],
+        'version_added': '2.2',
+    },
+    'disk_type': {
+        'description': ['The disk type of the volume.'],
+        'choices': ['HDD', 'SSD', 'SSD Premium', 'SSD Standard'],
+        'default': 'HDD',
+        'available': ['present'],
+        'type': 'str',
+    },
+    'licence_type': {
+        'description': ['The licence type for the volume. This is used when the image is non-standard.'],
+        'choices': ['LINUX', 'WINDOWS', 'UNKNOWN', 'OTHER', 'WINDOWS2016'],
+        'default': 'UNKNOWN',
+        'available': ['present'],
+        'type': 'str',
+    },
+    'availability_zone': {
+        'description': ['The storage availability zone assigned to the volume.'],
+        'choices': ['AUTO', 'ZONE_1', 'ZONE_2', 'ZONE_3'],
+        'available': ['present', 'update'],
+        'type': 'str',
+        'version_added': '2.3',
+    },
+    'count': {
+        'description': ['The number of volumes you wish to create.'],
+        'available': ['present'],
+        'default': 1,
+        'type': 'int',
+    },
+    'auto_increment': {
+        'description': ['Whether or not to increment a single number in the name for created virtual machines.'],
+        'available': ['present'],
+        'choices': [True, False],
+        'default': True,
+        'type': 'bool',
+    },
+    'instance_ids': {
+        'description': ["list of instance ids, currently only used when state='absent' to remove instances."],
+        'available': ['update', 'absent'],
+        'default': [],
+        'type': 'list',
+    },
+    'backupunit_id': {
+        'description': [
+            "The ID of the backup unit that the user has access to. The property is immutable and is only "
+            "allowed to be set on creation of a new a volume. It is mandatory to provide either 'public image' or 'imageAlias' "
+            "in conjunction with this property.",
+        ],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'user_data': {
+        'description': [
+            "The cloud-init configuration for the volume as base64 encoded string. The property is immutable "
+            "and is only allowed to be set on creation of a new a volume. It is mandatory to provide either 'public image' "
+            "or 'imageAlias' that has cloud-init compatibility in conjunction with this property.",
+        ],
+        'available': ['present'],
+        'type': 'str',
+    },
+    'cpu_hot_plug': {
+        'description': ['Hot-plug capable CPU (no reboot required).'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'ram_hot_plug': {
+        'description': ['Hot-plug capable RAM (no reboot required)'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'nic_hot_plug': {
+        'description': ['Hot-plug capable NIC (no reboot required).'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'nic_hot_unplug': {
+        'description': ['Hot-unplug capable NIC (no reboot required)'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'disc_virtio_hot_plug': {
+        'description': ['Hot-plug capable Virt-IO drive (no reboot required).'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'disc_virtio_hot_unplug': {
+        'description': ['Hot-unplug capable Virt-IO drive (no reboot required). Not supported with Windows VMs.'],
+        'available': ['present', 'update'],
+        'type': 'bool',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'wait': {
+        'description': ['Wait for the resource to be created before returning.'],
+        'default': True,
+        'available': STATES,
+        'choices': [True, False],
+        'type': 'bool',
+    },
+    'wait_timeout': {
+        'description': ['How long before wait gives up, in seconds.'],
+        'default': 600,
+        'available': STATES,
+        'type': 'int',
+    },
+    'state': {
+        'description': ['Indicate desired state of the resource.'],
+        'default': 'present',
+        'choices': STATES,
+        'available': STATES,
+        'type': 'str',
+    },
+}
 
-uuid_match = re.compile(
-    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: volume
+short_description: Create, update or destroy a volume.
+description:
+     - Allows you to create, update or remove a volume from a Ionos datacenter.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLE_PER_STATE = {
+  'present' : '''# Create Multiple Volumes
+  - volume:
+    datacenter: Tardis One
+    name: vol%02d
+    count: 5
+    auto_increment: yes
+    wait_timeout: 500
+    state: present
+  ''',
+  'update' : '''# Update Volumes
+  - volume:
+      datacenter: Tardis One
+      instance_ids:
+        - 'vol01'
+        - 'vol02'
+      size: 50
+      bus: IDE
+      wait_timeout: 500
+      state: update
+  ''',
+  'absent' : '''# Remove Volumes
+  - volume:
+    datacenter: Tardis One
+    instance_ids:
+      - 'vol01'
+      - 'vol02'
+    wait_timeout: 500
+    state: absent
+  ''',
+}
+
+EXAMPLES = '\n'.join(EXAMPLE_PER_STATE.values())
+
+uuid_match = re.compile('[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
 
 def _get_request_id(headers):
@@ -272,7 +349,6 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
     size = module.params.get('size')
     bus = module.params.get('bus')
     availability_zone = module.params.get('availability_zone')
-    licence_type = module.params.get('licence_type')
     cpu_hot_plug = module.params.get('cpu_hot_plug')
     ram_hot_plug = module.params.get('ram_hot_plug')
     nic_hot_plug = module.params.get('nic_hot_plug')
@@ -292,7 +368,7 @@ def _update_volume(module, volume_server, api_client, datacenter, volume_id):
                                              cpu_hot_plug=cpu_hot_plug, ram_hot_plug=ram_hot_plug,
                                              nic_hot_plug=nic_hot_plug, nic_hot_unplug=nic_hot_unplug,
                                              disc_virtio_hot_plug=disc_virtio_hot_plug,
-                                             disc_virtio_hot_unplug=disc_virtio_hot_unplug, licence_type=licence_type)
+                                             disc_virtio_hot_unplug=disc_virtio_hot_unplug)
         volume = Volume(properties=volume_properties)
         response = volume_server.datacenters_volumes_put_with_http_info(
             datacenter_id=datacenter,
@@ -571,60 +647,30 @@ def _get_resource(instance_list, identity):
     return None
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            datacenter=dict(type='str'),
-            server=dict(type='str'),
-            name=dict(type='str'),
-            size=dict(type='int', default=10),
-            image=dict(type='str'),
-            backupunit_id=dict(type='str'),
-            user_data=dict(type='str'),
-            image_password=dict(type='str', default=None, no_log=True),
-            ssh_keys=dict(type='list', default=[]),
-            cpu_hot_plug=dict(type='bool'),
-            ram_hot_plug=dict(type='bool'),
-            nic_hot_plug=dict(type='bool'),
-            nic_hot_unplug=dict(type='bool'),
-            disc_virtio_hot_plug=dict(type='bool'),
-            disc_virtio_hot_unplug=dict(type='bool'),
-            bus=dict(type='str', choices=BUS_TYPES, default='VIRTIO'),
-            disk_type=dict(type='str', choices=DISK_TYPES, default='HDD'),
-            licence_type=dict(type='str', choices=LICENCE_TYPES),
-            availability_zone=dict(type='str', choices=AVAILABILITY_ZONES, default=None),
-            count=dict(type='int', default=1),
-            auto_increment=dict(type='bool', default=True),
-            instance_ids=dict(type='list', default=[]),
-            api_url=dict(type='str', default=None, fallback=(env_fallback, ['IONOS_API_URL'])),
-            username=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_user'],
-                fallback=(env_fallback, ['IONOS_USERNAME'])
-            ),
-            password=dict(
-                type='str',
-                required=True,
-                aliases=['subscription_password'],
-                fallback=(env_fallback, ['IONOS_PASSWORD']),
-                no_log=True
-            ),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=600),
-            state=dict(type='str', default='present'),
-        ),
-        supports_check_mode=True
-    )
+def get_module_arguments():
+    arguments = {}
 
-    if not HAS_SDK:
-        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
 
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
-
-    user_agent = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % (__version__, sdk_version)
 
     conf = {
         'username': username,
@@ -635,41 +681,41 @@ def main():
         conf['host'] = api_url
         conf['server_index'] = None
 
-    configuration = ionoscloud.Configuration(**conf)
+    return sdk.Configuration(**conf)
+
+
+def check_required_arguments(module, state, object_name):
+    for option_name, option in OPTIONS.items():
+        if state in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for {object_name} state {state}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                    state=state,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
 
     state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, state, OBJECT_NAME)
 
-    with ApiClient(configuration) as api_client:
-        api_client.user_agent = user_agent
-
-        if state == 'absent':
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required for creating, updating or deleting volumes.')
-
-            try:
-                (result) = delete_volume(module, api_client)
-                module.exit_json(**result)
-            except Exception as e:
-                module.fail_json(msg='failed to set volume state: %s' % to_native(e))
-
-        elif state == 'present':
-            if not module.params.get('datacenter'):
-                module.fail_json(msg='datacenter parameter is required for new instance')
-            if not module.params.get('name'):
-                module.fail_json(msg='name parameter is required for new instance')
-
-            try:
-                (volume_dict_array) = create_volume(module, api_client)
-                module.exit_json(**volume_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to set volume state: %s' % to_native(e))
-
-        elif state == 'update':
-            try:
-                (volume_dict_array) = update_volume(module, api_client)
-                module.exit_json(**volume_dict_array)
-            except Exception as e:
-                module.fail_json(msg='failed to update volume: %s' % to_native(e))
+        try:
+            if state == 'absent':
+                module.exit_json(**delete_volume(module, api_client))
+            elif state == 'present':
+                module.exit_json(**create_volume(module, api_client))
+            elif state == 'update':
+                module.exit_json(**update_volume(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
 
 
 if __name__ == '__main__':

--- a/tests/s3key-test-idempotency.yml
+++ b/tests/s3key-test-idempotency.yml
@@ -1,0 +1,52 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+    - set_fact:
+        random_user: "no-reply{{100000000 |random}}@example.com"
+      run_once: yes
+
+    - name: Create user
+      user:
+        firstname: John
+        lastname: Doe
+        email: "{{ random_user }}"
+        administrator: true
+        user_password: "{{ password }}"
+        force_sec_auth: false
+        state: present
+      register: user_response
+
+    - name: Create an s3key with idempotency
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+        idempotency: True
+      register: s3key_created_one
+
+    - name: Create a second s3key with idempotency
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+        idempotency: True
+      register: s3key_created_two
+
+    - name: Testing if only one s3key exists
+      assert:
+        that:
+          - s3key_created_one == s3key_created_two
+        msg: "only one s3key must be created if using idempotency"  
+
+    - name: Remove an s3key
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+        key_id: "{{ s3key_created_one.s3key.id }}"
+        state: absent
+
+    - name: Remove an s3key - non existent
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+        key_id: "not-existent-key"
+        state: absent


### PR DESCRIPTION
## What does this fix or implement?

#67 

Added option to respect idempotency for s3key creation. Use `idempotency: True` to only create an S3key if it doesn't exist already.

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Documentation updated
- [x] Jira task updated
- [x] Wrote tests