### PR TITLE
feat: s3key idempotency (#67)

### DIFF
--- a/docs/api/user-management/s3key.md
+++ b/docs/api/user-management/s3key.md
@@ -46,6 +46,7 @@ This is a simple module that supports creating or removing S3Keys.
   | :--- | :---: | :--- | :--- | :--- |
   | active | False | bool |  | Denotes weather the S3 key is active. |
   | user_id | True | str |  | The ID of the user |
+  | idempotency | False | bool | False | Flag that dictates respecting idempotency. If an s3key already exists, returns with already existing key instead of creating more. |
   | api_url | False | str |  | The Ionos API base URL. |
   | username | False | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
   | password | False | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |

--- a/plugins/modules/s3key.py
+++ b/plugins/modules/s3key.py
@@ -43,7 +43,14 @@ OPTIONS = {
         'description': ['The ID of the S3 key.'],
         'available': ['absent', 'update'],
         'required': ['absent', 'update'],
-        'type': 'str',
+        'type': 'str', 
+    },
+    'idempotency': {
+        'description': ['If a key already exists, don\'t create any more on create requests'],
+        'default': False,
+        'available': 'present',
+        'choices': [True, False],
+        'type': 'bool',
     },
     'api_url': {
         'description': ['The Ionos API base URL.'],
@@ -159,11 +166,22 @@ def _get_request_id(headers):
 def create_s3key(module, client):
     user_id = module.params.get('user_id')
     wait = module.params.get('wait')
+    do_idempotency = module.params.get('idempotency')
     wait_timeout = int(module.params.get('wait_timeout'))
 
     user_s3keys_server = ionoscloud.UserS3KeysApi(client)
+    s3key_list = user_s3keys_server.um_users_s3keys_get(user_id=user_id, depth=5)
 
     try:
+        if (do_idempotency and len(s3key_list.items) > 0):
+            s3key_response = s3key_list.items[0]
+            return {
+                'changed': False,
+                'failed': False,
+                'action': 'create',
+                's3key': s3key_response.to_dict()
+            }
+
         response = user_s3keys_server.um_users_s3keys_post_with_http_info(user_id=user_id)
         (s3key_response, _, headers) = response
 

--- a/plugins/modules/s3key.py
+++ b/plugins/modules/s3key.py
@@ -46,7 +46,7 @@ OPTIONS = {
         'type': 'str', 
     },
     'idempotency': {
-        'description': ['If a key already exists, don\'t create any more on create requests'],
+        'description': ['Flag that dictates respecting idempotency. If an s3key already exists, returns with already existing key instead of creating more.'],
         'default': False,
         'available': 'present',
         'choices': [True, False],

--- a/tests/user-management/all-tests.yml
+++ b/tests/user-management/all-tests.yml
@@ -11,6 +11,9 @@
 - name: Run S3Key Test
   import_playbook: s3key-test.yml
 
+- name: Run S3Key Idempotency Test
+  import_playbook: s3key-idempotency-test.yml
+
 - name: Run S3Key Info Test
   import_playbook: s3key-info-test.yml
 

--- a/tests/user-management/s3key-idempotency-test.yml
+++ b/tests/user-management/s3key-idempotency-test.yml
@@ -21,34 +21,35 @@
         state: present
       register: user_response
 
-    - name: Create an s3key
+    - name: Create an s3key with idempotency
       s3key:
         user_id: "{{ user_response.user.id }}"
-      register: result
+        idempotency: True
+      register: s3key_created_one
 
-    - name: Debug - Show S3key
-      debug:
-        msg: "{{ result }}"
-
-    - name: Update an s3key
+    - name: Create a second s3key with idempotency
       s3key:
         user_id: "{{ user_response.user.id }}"
-        key_id: "{{ result.s3key.id }}"
-        active: False
-        state: update
+        idempotency: True
+      register: s3key_created_two
 
-    - name: Remove an s3key
+    - name: List S3Keys
+      s3key_info:
+        user_id: "{{ user_response.user.id }}"
+      register: s3keys_info_response
+
+    - name: Testing if only one s3key exists
+      assert:
+        that:
+          - s3keys_info_response.s3keys|length == 1
+        msg: "only one s3key must be created if using idempotency"
+
+    - name: Delete s3key
       s3key:
         user_id: "{{ user_response.user.id }}"
-        key_id: "{{ result.s3key.id }}"
+        key_id: "{{ s3key_created_one.s3key.id }}"
         state: absent
 
-    - name: Remove an s3key - non existent
-      s3key:
-        user_id: "{{ user_response.user.id }}"
-        key_id: "not-existent-key"
-        state: absent
-    
     - name: Delete user
       user:
         email: "{{ random_user }}"


### PR DESCRIPTION
## What does this fix or implement?

#67 

Added option to respect idempotency for s3key creation. Use `idempotency: True` to only create an S3key if it doesn't exist already.

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Documentation updated
- [x] Jira task updated
- [x] Wrote tests