### PR TITLE
 feat: s3key idempotency, v5 (#67) 

### DIFF
--- a/docs/api/user-management/s3key.md
+++ b/docs/api/user-management/s3key.md
@@ -30,4 +30,4 @@ The following parameters are supported:
 | user\_id | **yes** | string |  | The unique ID of the user. |
 | key\_id | **yes** | string |  | The ID of the key. Required only for state = 'update' or state = 'absent' |
 | active | no | boolean |  | State of the key. |
-
+| idempotency | no | boolean | False | Flag that dictates respecting idempotency. If an s3key already exists, returns with already existing key instead of creating more |


### PR DESCRIPTION
## What does this fix or implement?

(v5 branch)

#67 

Added option to respect idempotency for s3key creation. Use `idempotency: True` to only create an S3key if it doesn't exist already.

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Documentation updated
- [x] Jira task updated