### PR TITLE
feat: s3key info module

### DIFF
--- a/docs/api/dbaas-postgres/postgres_backup_info.md
+++ b/docs/api/dbaas-postgres/postgres_backup_info.md
@@ -24,6 +24,6 @@ This is a simple module that supports listing existing Postgres Cluster backups
 | :--- | :---: | :--- | :--- | :--- |
 | postgres_cluster | False | str |  | The ID or name of an existing Postgres Cluster. |
 | api_url | False | str |  | The Ionos API base URL. |
-| username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
-| password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
-| token | True | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |
+| username | False | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | False | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+| token | False | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |

--- a/docs/api/dbaas-postgres/postgres_cluster_info.md
+++ b/docs/api/dbaas-postgres/postgres_cluster_info.md
@@ -23,6 +23,6 @@ This is a simple module that supports listing existing Postgres Clusters
 | Name | Required | Type | Default | Description |
 | :--- | :---: | :--- | :--- | :--- |
 | api_url | False | str |  | The Ionos API base URL. |
-| username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
-| password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
-| token | True | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |
+| username | False | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | False | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+| token | False | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |

--- a/docs/api/user-management/s3key_info.md
+++ b/docs/api/user-management/s3key_info.md
@@ -23,6 +23,7 @@ This is a simple module that supports listing S3Keys.
 | Name | Required | Type | Default | Description |
 | :--- | :---: | :--- | :--- | :--- |
 | user_id | True | str |  | The ID of the user |
-| api_url | True | str |  | The Ionos API base URL. |
+| api_url | False | str |  | The Ionos API base URL. |
 | username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
 | password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+| token | False | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |

--- a/docs/api/user-management/s3key_info.md
+++ b/docs/api/user-management/s3key_info.md
@@ -1,0 +1,28 @@
+# s3key_info
+
+This is a simple module that supports listing S3Keys.
+
+## Example Syntax
+
+
+```yaml
+
+    - name: List S3Keys for user
+      s3key_info:
+        user_id: "{{ user_id }}"
+        register: s3key_info_response
+
+    - name: Show S3Keys
+      debug:
+        var: s3key_info_response.result
+
+```
+### Available parameters:
+&nbsp;
+
+| Name | Required | Type | Default | Description |
+| :--- | :---: | :--- | :--- | :--- |
+| user_id | True | str |  | The ID of the user |
+| api_url | True | str |  | The Ionos API base URL. |
+| username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |

--- a/docs_generator.py
+++ b/docs_generator.py
@@ -87,6 +87,7 @@ modules_to_generate = [
     'network_load_balancer',
     'group',
     's3key',
+    's3key_info',
     'share',
     'user',
 ]

--- a/plugins/modules/s3key_info.py
+++ b/plugins/modules/s3key_info.py
@@ -1,0 +1,183 @@
+import re
+import copy
+import yaml
+
+HAS_SDK = True
+try:
+    import ionoscloud
+    from ionoscloud import __version__ as sdk_version
+    from ionoscloud.models import S3Key
+    from ionoscloud.models import S3KeyProperties
+    from ionoscloud.rest import ApiException
+    from ionoscloud import ApiClient
+except ImportError:
+    HAS_SDK = False
+
+from ansible import __version__
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+DOC_DIRECTORY = 'user-management'
+STATES = ['info']
+OBJECT_NAME = 'S3 Key'
+
+OPTIONS = {
+    'user_id': {
+        'description': ['The ID of the user'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'required': STATES,
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'required': STATES,
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+}
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES) 
+    del val['available']
+    del val['type']
+    return val
+
+DOCUMENTATION = '''
+---
+module: s3key_info
+short_description: List Ionos Cloud S3Keys of a given user.
+description:
+     - This is a simple module that supports listing S3Keys.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.0"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLES = '''
+    - name: List S3Keys for user
+      s3key_info:
+        user_id: "{{ user_id }}"
+        register: s3key_info_response
+
+    - name: Show S3Keys
+      debug:
+        var: s3key_info_response.result
+'''
+
+
+def get_s3keys(module, client):
+    user_id = module.params.get('user_id')
+    user_s3keys_server = ionoscloud.UserS3KeysApi(client)
+
+    try:
+        s3key_response = user_s3keys_server.um_users_s3keys_get(user_id, depth=5)
+        return {
+            'action': 'info',
+            'changed': False,
+            's3keys': s3key_response.to_dict()
+        }
+
+    except Exception as e:
+        module.fail_json(msg="failed to list the s3keys: %s" % to_native(e))
+        return {
+            'action': 'info',
+            'changed': False,
+        }
+
+
+def get_module_arguments():
+    arguments = {}
+
+    for option_name, option in OPTIONS.items():
+      arguments[option_name] = {
+        'type': option['type'],
+      }
+      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+        if option.get(key) is not None:
+          arguments[option_name][key] = option.get(key)
+
+      if option.get('env_fallback'):
+        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+      if len(option.get('required', [])) == len(STATES):
+        arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
+    username = module.params.get('username')
+    password = module.params.get('password')
+    api_url = module.params.get('api_url')
+
+    conf = {
+        'username': username,
+        'password': password,
+    }
+
+    if api_url is not None:
+        conf['host'] = api_url
+        conf['server_index'] = None
+
+    return sdk.Configuration(**conf)
+
+
+def check_required_arguments(module, object_name):
+    for option_name, option in OPTIONS.items():
+        if 'info' in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for retrieving {object_name}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, OBJECT_NAME)
+
+        try:
+            module.exit_json(**get_s3keys(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/s3key_info.py
+++ b/plugins/modules/s3key_info.py
@@ -99,11 +99,13 @@ def get_s3keys(module, client):
     user_s3keys_server = ionoscloud.UserS3KeysApi(client)
 
     try:
-        s3key_response = user_s3keys_server.um_users_s3keys_get(user_id, depth=5)
+        results = []
+        for s3key in user_s3keys_server.um_users_s3keys_get(user_id).items:
+            results.append(s3key.to_dict())
         return {
             'action': 'info',
             'changed': False,
-            's3keys': s3key_response.to_dict()
+            's3keys': results
         }
 
     except Exception as e:

--- a/plugins/modules/s3key_info.py
+++ b/plugins/modules/s3key_info.py
@@ -117,10 +117,6 @@ def get_s3keys(module, client):
 
     except Exception as e:
         module.fail_json(msg="failed to list the s3keys: %s" % to_native(e))
-        return {
-            'action': 'info',
-            'changed': False,
-        }
 
 
 def get_module_arguments():

--- a/plugins/modules/s3key_info.py
+++ b/plugins/modules/s3key_info.py
@@ -6,9 +6,6 @@ HAS_SDK = True
 try:
     import ionoscloud
     from ionoscloud import __version__ as sdk_version
-    from ionoscloud.models import S3Key
-    from ionoscloud.models import S3KeyProperties
-    from ionoscloud.rest import ApiException
     from ionoscloud import ApiClient
 except ImportError:
     HAS_SDK = False
@@ -42,6 +39,7 @@ OPTIONS = {
         'type': 'str',
     },
     'username': {
+        # Required if no token, checked manually
         'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
         'aliases': ['subscription_user'],
         'required': STATES,
@@ -50,12 +48,21 @@ OPTIONS = {
         'type': 'str',
     },
     'password': {
+        # Required if no token, checked manually
         'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
         'aliases': ['subscription_password'],
         'required': STATES,
         'available': STATES,
         'no_log': True,
         'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'token': {
+        # If provided, then username and password no longer required
+        'description': ['The Ionos token. Overrides the IONOS_TOKEN environment variable.'],
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_TOKEN',
         'type': 'str',
     },
 }
@@ -77,7 +84,7 @@ options:
 ''' + '  ' + yaml.dump(yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})), default_flow_style=False).replace('\n', '\n  ') + '''
 requirements:
     - "python >= 2.6"
-    - "ionoscloud >= 6.0.0"
+    - "ionoscloud >= 6.0.2"
 author:
     - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
 '''
@@ -140,11 +147,19 @@ def get_sdk_config(module, sdk):
     username = module.params.get('username')
     password = module.params.get('password')
     api_url = module.params.get('api_url')
+    token = module.params.get('token')
 
-    conf = {
-        'username': username,
-        'password': password,
-    }
+    if token is not None:
+        # use the token instead of username & password
+        conf = {
+            'token': token
+        }
+    else:
+        # use the username & password
+        conf = {
+            'username': username,
+            'password': password,
+        }
 
     if api_url is not None:
         conf['host'] = api_url
@@ -154,6 +169,17 @@ def get_sdk_config(module, sdk):
 
 
 def check_required_arguments(module, object_name):
+    # manually checking if token or username & password provided
+    if (
+        not module.params.get("token")
+        and not (module.params.get("username") and module.params.get("password"))
+    ):
+        module.fail_json(
+            msg='Token or username & password are required for {object_name}'.format(
+                object_name=object_name,
+            ),
+        )
+
     for option_name, option in OPTIONS.items():
         if 'info' in option.get('required', []) and not module.params.get(option_name):
             module.fail_json(

--- a/tests/user-management/all-tests.yml
+++ b/tests/user-management/all-tests.yml
@@ -11,5 +11,8 @@
 - name: Run S3Key Test
   import_playbook: s3key-test.yml
 
+- name: Run S3Key Info Test
+  import_playbook: s3key-info-test.yml
+
 - name: Run Share Test
   import_playbook: share-test.yml

--- a/tests/user-management/s3key-info-test.yml
+++ b/tests/user-management/s3key-info-test.yml
@@ -1,0 +1,44 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - ../vars.yml
+
+  tasks:
+    - set_fact:
+        random_user: "no-reply{{100000000 |random}}@example.com"
+      run_once: yes
+
+    - name: Create user
+      user:
+        firstname: John
+        lastname: Doe
+        email: "{{ random_user }}"
+        administrator: true
+        user_password: "{{ password }}"
+        force_sec_auth: false
+        state: present
+      register: user_response
+
+    - name: Create a first s3key
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+
+    - name: Create a second s3key
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+
+    - name: List S3Keys
+      s3key_info:
+        user_id: "{{ user_response.user.id }}"
+      register: s3keys_info_response
+
+    - name: Debug - Show response of s3keys_info
+      debug:
+        msg: "{{ s3keys_info_response }}"
+
+    - name: Delete user
+      user:
+        email: "{{ random_user }}"
+        state: absent

--- a/tests/user-management/s3key-info-test.yml
+++ b/tests/user-management/s3key-info-test.yml
@@ -36,7 +36,7 @@
 
     - name: Debug - Show response of s3keys_info
       debug:
-        msg: "{{ s3keys_info_response }}"
+        msg: "{{ s3keys_info_response.s3keys }}"
 
     - name: Delete user
       user:

--- a/tests/user-management/s3key-info-test.yml
+++ b/tests/user-management/s3key-info-test.yml
@@ -24,10 +24,12 @@
     - name: Create a first s3key
       s3key:
         user_id: "{{ user_response.user.id }}"
+      register: s3key_response_first
 
     - name: Create a second s3key
       s3key:
         user_id: "{{ user_response.user.id }}"
+      register: s3key_response_second
 
     - name: List S3Keys
       s3key_info:
@@ -37,6 +39,18 @@
     - name: Debug - Show response of s3keys_info
       debug:
         msg: "{{ s3keys_info_response.s3keys }}"
+
+    - name: Delete first s3key
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+        key_id: "{{ s3key_response_first.s3key.id }}"
+        state: absent
+
+    - name: Delete second s3key
+      s3key:
+        user_id: "{{ user_response.user.id }}"
+        key_id: "{{ s3key_response_second.s3key.id }}"
+        state: absent
 
     - name: Delete user
       user:

--- a/tests/user-management/s3key-test.yml
+++ b/tests/user-management/s3key-test.yml
@@ -48,3 +48,8 @@
         user_id: "{{ user_response.user.id }}"
         key_id: "not-existent-key"
         state: absent
+    
+    - name: Delete user
+      user:
+        email: "{{ random_user }}"
+        state: absent


### PR DESCRIPTION
## What does this fix or implement?

Added module to get all s3keys for a given user id. This helps users make more customized playbooks and also helps us with our tests (see #69: instead of checking if two idempotently-created s3keys are equal, perform a GET operation and check if only one was created)

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Documentation updated
- [x] Jira task updated
- [x] Wrote tests