### PR TITLE
feat: server info module (#22)

### DIFF
--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -237,7 +237,7 @@ Create, update, destroy, update, start, stop, and reboot a Ionos virtual machine
   | instance_ids | False | list |  | list of instance ids, currently only used when state='absent' to remove instances. |
   | count | False | int | 1 | The number of virtual machines to create. |
   | location | False | str | us/las | The datacenter location. Use only if you want to create the Datacenter or else this value is ignored. |
-  | lan | False | str | 1 | The ID or name of the LAN you wish to add the servers to (can be a string or a number). |
+  | lan | False | str |  | The ID or name of the LAN you wish to add the servers to (can be a string or a number). |
   | nat | False | bool | False | Boolean value indicating if the private IP address has outbound access to the public Internet. |
   | remove_boot_volume | False | bool | True | Remove the bootVolume of the virtual machine you're destroying. |
   | disk_type | False | str | HDD | The disk type for the volume. |

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -237,7 +237,7 @@ Create, update, destroy, update, start, stop, and reboot a Ionos virtual machine
   | instance_ids | False | list |  | list of instance ids, currently only used when state='absent' to remove instances. |
   | count | False | int | 1 | The number of virtual machines to create. |
   | location | False | str | us/las | The datacenter location. Use only if you want to create the Datacenter or else this value is ignored. |
-  | lan | False | raw |  | The ID or name of the LAN you wish to add the servers to (can be a string or a number). |
+  | lan | False | str | 1 | The ID or name of the LAN you wish to add the servers to (can be a string or a number). |
   | nat | False | bool | False | Boolean value indicating if the private IP address has outbound access to the public Internet. |
   | remove_boot_volume | False | bool | True | Remove the bootVolume of the virtual machine you're destroying. |
   | disk_type | False | str | HDD | The disk type for the volume. |

--- a/docs/api/compute-engine/server_info.md
+++ b/docs/api/compute-engine/server_info.md
@@ -1,0 +1,40 @@
+# server_info
+
+This is a simple module that supports listing servers.
+
+## Example Syntax
+
+
+```yaml
+
+    - name: Get all servers for given datacenter
+      server_info:
+        datacenter: "{{ datacenter }}"
+      register: server_list_response
+
+    - name: Get only the servers that need to be upgraded
+      server_info:
+        datacenter: "{{ datacenter }}"
+        upgrade_needed: true
+      register: servers_list_upgrade_response
+
+    - name: Show all servers for the created datacenter
+      debug:
+        var: server_list_response
+
+    - name: Show servers that need an upgrade
+      debug:
+        var: servers_list_upgrade_response
+
+```
+### Available parameters:
+&nbsp;
+
+| Name | Required | Type | Default | Description |
+| :--- | :---: | :--- | :--- | :--- |
+| datacenter | True | str |  | The ID of the datacenter. |
+| upgrade_needed | False | bool |  | Filter servers that can or that cannot be upgraded. |
+| api_url | False | str |  | The Ionos API base URL. |
+| username | False | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | False | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+| token | False | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |

--- a/docs/api/user-management/s3key_info.md
+++ b/docs/api/user-management/s3key_info.md
@@ -24,6 +24,6 @@ This is a simple module that supports listing S3Keys.
 | :--- | :---: | :--- | :--- | :--- |
 | user_id | True | str |  | The ID of the user |
 | api_url | False | str |  | The Ionos API base URL. |
-| username | True | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
-| password | True | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
+| username | False | str |  | The Ionos username. Overrides the IONOS_USERNAME environment variable. |
+| password | False | str |  | The Ionos password. Overrides the IONOS_PASSWORD environment variable. |
 | token | False | str |  | The Ionos token. Overrides the IONOS_TOKEN environment variable. |

--- a/docs_generator.py
+++ b/docs_generator.py
@@ -70,6 +70,7 @@ modules_to_generate = [
     'nic',
     'pcc',
     'server',
+    'server_info',
     'snapshot',
     'volume',
     'postgres_cluster',

--- a/plugins/modules/s3key_info.py
+++ b/plugins/modules/s3key_info.py
@@ -19,10 +19,10 @@ ANSIBLE_METADATA = {
     'status': ['preview'],
     'supported_by': 'community',
 }
-USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % ( __version__, sdk_version)
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % (__version__, sdk_version)
 DOC_DIRECTORY = 'user-management'
 STATES = ['info']
-OBJECT_NAME = 'S3 Key'
+OBJECT_NAME = 'S3 Keys'
 
 OPTIONS = {
     'user_id': {
@@ -42,7 +42,6 @@ OPTIONS = {
         # Required if no token, checked manually
         'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
         'aliases': ['subscription_user'],
-        'required': STATES,
         'env_fallback': 'IONOS_USERNAME',
         'available': STATES,
         'type': 'str',
@@ -51,7 +50,6 @@ OPTIONS = {
         # Required if no token, checked manually
         'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
         'aliases': ['subscription_password'],
-        'required': STATES,
         'available': STATES,
         'no_log': True,
         'env_fallback': 'IONOS_PASSWORD',
@@ -67,11 +65,13 @@ OPTIONS = {
     },
 }
 
+
 def transform_for_documentation(val):
-    val['required'] = len(val.get('required', [])) == len(STATES) 
+    val['required'] = len(val.get('required', [])) == len(STATES)
     del val['available']
     del val['type']
     return val
+
 
 DOCUMENTATION = '''
 ---
@@ -123,18 +123,18 @@ def get_module_arguments():
     arguments = {}
 
     for option_name, option in OPTIONS.items():
-      arguments[option_name] = {
-        'type': option['type'],
-      }
-      for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
-        if option.get(key) is not None:
-          arguments[option_name][key] = option.get(key)
+        arguments[option_name] = {
+            'type': option['type'],
+        }
+        for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+            if option.get(key) is not None:
+                arguments[option_name][key] = option.get(key)
 
-      if option.get('env_fallback'):
-        arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+        if option.get('env_fallback'):
+            arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
 
-      if len(option.get('required', [])) == len(STATES):
-        arguments[option_name]['required'] = True
+        if len(option.get('required', [])) == len(STATES):
+            arguments[option_name]['required'] = True
 
     return arguments
 
@@ -200,7 +200,9 @@ def main():
         try:
             module.exit_json(**get_s3keys(module, api_client))
         except Exception as e:
-            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME, error=to_native(e), state=state))
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME,
+                                                                                             error=to_native(e),
+                                                                                             state=state))
 
 
 if __name__ == '__main__':

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -165,13 +165,7 @@ OPTIONS = {
     'lan': {
         'description': ['The ID or name of the LAN you wish to add the servers to (can be a string or a number).'],
         'available': ['present'],
-        'default': '1',
         'type': 'str',
-    },
-    'lan': {
-        'description': ['The ID or name of the LAN you wish to add the servers to (can be a string or a number).'],
-        'available': ['present'],
-        'type': 'raw',
     },
     'nat': {
         'description': ['Boolean value indicating if the private IP address has outbound access to the public Internet.'],

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -1,0 +1,240 @@
+import re
+import copy
+import yaml
+
+HAS_SDK = True
+try:
+    import ionoscloud
+    from ionoscloud import __version__ as sdk_version
+    from ionoscloud import ApiClient
+except ImportError:
+    HAS_SDK = False
+
+from ansible import __version__
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_native
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+USER_AGENT = 'ansible-module/%s_ionos-cloud-sdk-python/%s' % (__version__, sdk_version)
+DOC_DIRECTORY = 'compute-engine'
+STATES = ['info']
+OBJECT_NAME = 'Servers'
+
+OPTIONS = {
+    'datacenter': {
+        'description': ['The ID of the datacenter.'],
+        'available': STATES,
+        'required': STATES,
+        'type': 'str',
+    },
+    'upgrade_needed': {
+        'description': ['Filter servers that can or that cannot be upgraded.'],
+        'available': STATES,
+        'type': 'bool',
+    },
+    'api_url': {
+        'description': ['The Ionos API base URL.'],
+        'version_added': '2.4',
+        'env_fallback': 'IONOS_API_URL',
+        'available': STATES,
+        'type': 'str',
+    },
+    'username': {
+        # Required if no token, checked manually
+        'description': ['The Ionos username. Overrides the IONOS_USERNAME environment variable.'],
+        'aliases': ['subscription_user'],
+        'env_fallback': 'IONOS_USERNAME',
+        'available': STATES,
+        'type': 'str',
+    },
+    'password': {
+        # Required if no token, checked manually
+        'description': ['The Ionos password. Overrides the IONOS_PASSWORD environment variable.'],
+        'aliases': ['subscription_password'],
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_PASSWORD',
+        'type': 'str',
+    },
+    'token': {
+        # If provided, then username and password no longer required
+        'description': ['The Ionos token. Overrides the IONOS_TOKEN environment variable.'],
+        'available': STATES,
+        'no_log': True,
+        'env_fallback': 'IONOS_TOKEN',
+        'type': 'str',
+    },
+}
+
+
+def transform_for_documentation(val):
+    val['required'] = len(val.get('required', [])) == len(STATES)
+    del val['available']
+    del val['type']
+    return val
+
+
+DOCUMENTATION = '''
+---
+module: server_info
+short_description: List Ionos Cloud servers of a given datacenter.
+description:
+     - This is a simple module that supports listing servers.
+version_added: "2.0"
+options:
+''' + '  ' + yaml.dump(
+    yaml.safe_load(str({k: transform_for_documentation(v) for k, v in copy.deepcopy(OPTIONS).items()})),
+    default_flow_style=False).replace('\n', '\n  ') + '''
+requirements:
+    - "python >= 2.6"
+    - "ionoscloud >= 6.0.2"
+author:
+    - "IONOS Cloud SDK Team <sdk-tooling@ionos.com>"
+'''
+
+EXAMPLES = '''
+    - name: Get all servers for given datacenter
+      server_info:
+        datacenter: "{{ datacenter }}"
+      register: server_list_response
+
+    - name: Get only the servers that need to be upgraded
+      server_info:
+        datacenter: "{{ datacenter }}"
+        upgrade_needed: true
+      register: servers_list_upgrade_response
+
+    - name: Show all servers for the created datacenter
+      debug:
+        var: server_list_response
+
+    - name: Show servers that need an upgrade
+      debug:
+        var: servers_list_upgrade_response
+'''
+
+uuid_match = re.compile(
+    '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
+
+
+def get_servers(module, client):
+    datacenter = module.params.get('datacenter')
+    servers_api = ionoscloud.ServersApi(client)
+    datacenter_server = ionoscloud.DataCentersApi(api_client=client)
+    upgrade_needed = module.params.get('upgrade_needed')
+
+    # Locate UUID for Datacenter
+    if not (uuid_match.match(datacenter)):
+        datacenter_list = datacenter_server.datacenters_get(depth=2)
+        for d in datacenter_list.items:
+            dc = datacenter_server.datacenters_find_by_id(datacenter_id=d.id)
+            if datacenter == dc.properties.name:
+                datacenter = d.id
+                break
+
+    try:
+        results = []
+        for server in servers_api.datacenters_servers_get(datacenter, upgrade_needed=upgrade_needed).items:
+            results.append(server.to_dict())
+        return {
+            'action': 'info',
+            'changed': False,
+            'servers': results
+        }
+
+    except Exception as e:
+        module.fail_json(msg="failed to list the servers: %s" % to_native(e))
+
+
+def get_module_arguments():
+    arguments = {}
+
+    for option_name, option in OPTIONS.items():
+        arguments[option_name] = {
+            'type': option['type'],
+        }
+        for key in ['choices', 'default', 'aliases', 'no_log', 'elements']:
+            if option.get(key) is not None:
+                arguments[option_name][key] = option.get(key)
+
+        if option.get('env_fallback'):
+            arguments[option_name]['fallback'] = (env_fallback, [option['env_fallback']])
+
+        if len(option.get('required', [])) == len(STATES):
+            arguments[option_name]['required'] = True
+
+    return arguments
+
+
+def get_sdk_config(module, sdk):
+    username = module.params.get('username')
+    password = module.params.get('password')
+    api_url = module.params.get('api_url')
+    token = module.params.get('token')
+
+    if token is not None:
+        # use the token instead of username & password
+        conf = {
+            'token': token
+        }
+    else:
+        # use the username & password
+        conf = {
+            'username': username,
+            'password': password,
+        }
+
+    if api_url is not None:
+        conf['host'] = api_url
+        conf['server_index'] = None
+
+    return sdk.Configuration(**conf)
+
+
+def check_required_arguments(module, object_name):
+    # manually checking if token or username & password provided
+    if (
+            not module.params.get("token")
+            and not (module.params.get("username") and module.params.get("password"))
+    ):
+        module.fail_json(
+            msg='Token or username & password are required for {object_name}'.format(
+                object_name=object_name,
+            ),
+        )
+
+    for option_name, option in OPTIONS.items():
+        if 'info' in option.get('required', []) and not module.params.get(option_name):
+            module.fail_json(
+                msg='{option_name} parameter is required for retrieving {object_name}'.format(
+                    option_name=option_name,
+                    object_name=object_name,
+                ),
+            )
+
+
+def main():
+    module = AnsibleModule(argument_spec=get_module_arguments(), supports_check_mode=True)
+
+    if not HAS_SDK:
+        module.fail_json(msg='ionoscloud is required for this module, run `pip install ionoscloud`')
+
+    state = module.params.get('state')
+    with ApiClient(get_sdk_config(module, ionoscloud)) as api_client:
+        api_client.user_agent = USER_AGENT
+        check_required_arguments(module, OBJECT_NAME)
+
+        try:
+            module.exit_json(**get_servers(module, api_client))
+        except Exception as e:
+            module.fail_json(msg='failed to set {object_name} state {state}: {error}'.format(object_name=OBJECT_NAME,
+                                                                                             error=to_native(e),
+                                                                                             state=state))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/server_info.py
+++ b/plugins/modules/server_info.py
@@ -120,6 +120,17 @@ EXAMPLES = '''
 uuid_match = re.compile(
     '[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}', re.I)
 
+def _get_resource(resource_list, identity):
+    """
+    Fetch and return a resource regardless of whether the name or
+    UUID is passed. Returns None error otherwise.
+    """
+
+    for resource in resource_list.items:
+        if identity in (resource.properties.name, resource.id):
+            return resource.id
+
+    return None
 
 def get_servers(module, client):
     datacenter = module.params.get('datacenter')
@@ -130,11 +141,7 @@ def get_servers(module, client):
     # Locate UUID for Datacenter
     if not (uuid_match.match(datacenter)):
         datacenter_list = datacenter_server.datacenters_get(depth=2)
-        for d in datacenter_list.items:
-            dc = datacenter_server.datacenters_find_by_id(datacenter_id=d.id)
-            if datacenter == dc.properties.name:
-                datacenter = d.id
-                break
+        datacenter = _get_resource(datacenter_list, datacenter)
 
     try:
         results = []

--- a/tests/compute-engine/all-tests.yml
+++ b/tests/compute-engine/all-tests.yml
@@ -35,6 +35,12 @@
 - name: Run PCC Test
   import_playbook: pcc-test.yml
 
+- name: Run Server Test
+  import_playbook: server-test.yml
+
+- name: Run Server-info Test
+  import_playbook: server-info-test.yml
+
 - name: Run Snapshot Test
   import_playbook: snapshot-test.yml
 

--- a/tests/compute-engine/server-info-test.yml
+++ b/tests/compute-engine/server-info-test.yml
@@ -12,35 +12,35 @@
   tasks:
     - name: Create datacenter
       datacenter:
-          name: "{{ datacenter }}"
-          location: "{{ location }}"
+        name: "{{ datacenter }}"
+        location: "{{ location }}"
 
     - name: Provision a server
       server:
-         datacenter: "{{ datacenter }}"
-         name: "{{ name }} %02d"
-         auto_increment: true
-         cores: 1
-         ram: 1024
-         availability_zone: ZONE_1
-         volume_availability_zone: ZONE_3
-         volume_size: 5
-         cpu_family: INTEL_SKYLAKE
-         disk_type: SSD Standard
-         image: "{{ image_alias }}"
-         image_password: "{{ password }}"
-         location: "{{ location }}"
-         count: 1
-         assign_public_ip: true
-         remove_boot_volume: true
-         wait: true
-         wait_timeout: "{{ wait_timeout }}"
-         state: present
+        datacenter: "{{ datacenter }}"
+        name: "{{ name }} %02d"
+        auto_increment: true
+        cores: 1
+        ram: 1024
+        availability_zone: ZONE_1
+        volume_availability_zone: ZONE_3
+        volume_size: 5
+        cpu_family: INTEL_SKYLAKE
+        disk_type: SSD Standard
+        image: "{{ image_alias }}"
+        image_password: "{{ password }}"
+        location: "{{ location }}"
+        count: 1
+        assign_public_ip: true
+        remove_boot_volume: true
+        wait: true
+        wait_timeout: "{{ wait_timeout }}"
+        state: present
 
     - name: Get all servers for given datacenter
       server_info:
         datacenter: "{{ datacenter }}"
-        register: server_list_response
+      register: server_list_response
 
     - name: Get only the servers that need to be upgraded
       server_info:
@@ -50,11 +50,11 @@
 
     - name: Show all servers for the created datacenter
       debug:
-        var: server_list_response.result
+        var: server_list_response
 
     - name: Show servers that need an upgrade
       debug:
-        var: servers_list_upgrade_response.result
+        var: servers_list_upgrade_response
 
     - name: Remove server
       server:

--- a/tests/compute-engine/server-info-test.yml
+++ b/tests/compute-engine/server-info-test.yml
@@ -1,0 +1,72 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    ssh_public_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+
+  vars_files:
+    - ../vars.yml
+
+  tasks:
+    - name: Create datacenter
+      datacenter:
+          name: "{{ datacenter }}"
+          location: "{{ location }}"
+
+    - name: Provision a server
+      server:
+         datacenter: "{{ datacenter }}"
+         name: "{{ name }} %02d"
+         auto_increment: true
+         cores: 1
+         ram: 1024
+         availability_zone: ZONE_1
+         volume_availability_zone: ZONE_3
+         volume_size: 5
+         cpu_family: INTEL_SKYLAKE
+         disk_type: SSD Standard
+         image: "{{ image_alias }}"
+         image_password: "{{ password }}"
+         location: "{{ location }}"
+         count: 1
+         assign_public_ip: true
+         remove_boot_volume: true
+         wait: true
+         wait_timeout: "{{ wait_timeout }}"
+         state: present
+
+    - name: Get all servers for given datacenter
+      server_info:
+        datacenter: "{{ datacenter }}"
+        register: server_list_response
+
+    - name: Get only the servers that need to be upgraded
+      server_info:
+        datacenter: "{{ datacenter }}"
+        upgrade_needed: true
+      register: servers_list_upgrade_response
+
+    - name: Show all servers for the created datacenter
+      debug:
+        var: server_list_response.result
+
+    - name: Show servers that need an upgrade
+      debug:
+        var: servers_list_upgrade_response.result
+
+    - name: Remove server
+      server:
+         datacenter: "{{ datacenter }}"
+         instance_ids:
+           - "{{ name }} 01"
+         remove_boot_volume: yes
+         wait_timeout: "{{ wait_timeout }}"
+         state: absent
+
+    - name: Remove datacenter
+      datacenter:
+        name: "{{ datacenter }}"
+        state: absent
+        wait: true


### PR DESCRIPTION
## What does this fix or implement?

(#22)

Added module to get all servers for a given datacenter id.

Use optional param `upgrade_needed` (boolean) to only list those servers that need / don't need an upgrade

This PR also has some out-of-scope fixes:
    - made s3key_info only require token or username and password for auth
    - fixed s3key_info name (for info modules should be plural): S3 Key to S3 Keys
    - added test for server module in compute-engine/all-tests
    - removed duplicate `lan` param for server module

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Documentation updated
- [x] Jira task updated
- [x] Wrote tests