### PR TITLE
Feat: add user_data param for server

### DIFF
--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -240,6 +240,7 @@ Create, update, destroy, update, start, stop, and reboot a Ionos virtual machine
   | image | True | str |  | The image alias or ID for creating the virtual machine. |
   | image_password | False | str |  | Password set for the administrative user. |
   | ssh_keys | False | list |  | Public SSH keys allowing access to the virtual machine. |
+  | user_data | False | str |  | The cloud-init configuration for the volume as base64 encoded string. |
   | volume_availability_zone | False | str |  | The storage availability zone assigned to the volume. |
   | datacenter | True | str |  | The datacenter to provision this virtual machine. |
   | cores | False | int | 2 | The number of CPU cores to allocate to the virtual machine. |

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -82,6 +82,11 @@ OPTIONS = {
         'default': [],
         'type': 'list',
     },
+    'user_data': {
+        'description': ['The cloud-init configuration for the volume as base64 encoded string.'],
+        'available': ['present'],
+        'type': 'str',
+    },
     'volume_availability_zone': {
         'description': ['The storage availability zone assigned to the volume.'],
         'available': ['present'],
@@ -437,6 +442,7 @@ def _create_machine(module, client, datacenter, name):
     volume_availability_zone = module.params.get('volume_availability_zone')
     image_password = module.params.get('image_password')
     ssh_keys = module.params.get('ssh_keys')
+    user_data = module.params.get('user_data')
     bus = module.params.get('bus')
     lan = module.params.get('lan')
     nat = module.params.get('nat')
@@ -507,6 +513,7 @@ def _create_machine(module, client, datacenter, name):
                                              availability_zone=volume_availability_zone,
                                              image_password=image_password,
                                              ssh_keys=ssh_keys,
+                                             user_data=user_data,
                                              bus=bus)
 
     if image:

--- a/tests/_resources/cloud-init.txt
+++ b/tests/_resources/cloud-init.txt
@@ -1,0 +1,6 @@
+#!/bin/bash
+dd if=/dev/zero of=/swapfile bs=1M count=4096
+chmod 0600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile    none    swap    sw    0    0' >> /etc/fstab

--- a/tests/compute-engine/server-test.yml
+++ b/tests/compute-engine/server-test.yml
@@ -5,6 +5,7 @@
 
   vars:
     ssh_public_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+    cloud_init_file: ../_resources/cloud-init.txt
 
   vars_files:
     - ../vars.yml
@@ -14,6 +15,10 @@
       datacenter:
           name: "{{ datacenter }}"
           location: "{{ location }}"
+
+    - name: Base64 encode the cloud-init config file '{{ cloud_init_file }}' for user_data in server provisioning
+      shell: base64 -w 0 "{{ cloud_init_file }}"
+      register: cloud_init_config
 
     - name: Provision a server
       server:
@@ -29,6 +34,7 @@
          image: "{{ image_alias }}"
          image_password: "{{ password }}"
          location: "{{ location }}"
+         user_data: "{{ cloud_init_config.stdout }}"
          count: 2
          assign_public_ip: true
          remove_boot_volume: true


### PR DESCRIPTION
## What does this fix or implement?

Added user_data parameter to server module. Credits to Peter Metz for the well-documented user story, quoted below:

>As a user, I want to be able to specify a cloud-init configuration when creating servers using the IONOS Cloud Ansible module.
>
> My reasoning behind this proposal is:
> 
> - cloud-init is a very common way of configuring servers in cloud settings, and if the DCD supports this kind of automation, the Ansible module should, too;
> 
> - While this can, of course, be done by first creating a volume (and giving it the encoded cloud-init config string) and then attaching it to the desired server, given the current problems with the inventory plugin, actually doing this from within an Ansible playbook is rather ... convoluted (and, I believe, requires calling the ionosctl tool via the shell module — see https://gitlab.pb.local/pmetz/automation-snippets/-/tree/master/ionos-cloud/ansible/example_for_ticket_207103549 for an example of what's currently involved);
> 
> - The server module already 'wraps' some of the volume creation / 'present' call's parameters for convenience's sake (e.g. image_password and ssh_keys), and given the pervasiveness of cloud-init, I think adding a user_data parameter is consistent with the existing proxy / convenience parameters;
> 
> - Given various issues in recent times with IONOS-provided images being pushed out onto customers without their ability to test and evaluate the updates (and given their inability to reference older versions so they can test these changes while continuing to use even the previous version for 'production' in the meantime), I think customers having the ability to apply certain checks / changes at first-boot time makes a lot of sense;

 
## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x]  Documentation updated
- [x] Jira task updated
- [x] Wrote tests