### PR TITLE
Fix: idempotency for volume, server creation

### DIFF
--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -710,16 +710,14 @@ def create_virtual_machine(module, client):
         names = [name]
 
     server_list = server_server.datacenters_servers_get(datacenter_id=datacenter_id, depth=1)
-    for name in names:
-        # Fail server creation if a server with this name and int combination already exists.
-        if get_resource_id(module, server_list, name) is not None:
-            module.fail_json(msg="Server with name %s already exists" % name, exception=traceback.format_exc())
-
     changed = False
-    # Prefetch a list of servers for later comparison.
     for name in names:
-        create_response = _create_machine(module, client, str(datacenter_id), name)
-        changed = True
+        existing_server_id = get_resource_id(module, server_list, name)
+        if existing_server_id is not None:
+            create_response = server_server.datacenters_servers_find_by_id(datacenter_id, existing_server_id, depth=1)
+        else:
+            create_response = _create_machine(module, client, str(datacenter_id), name)
+            changed = True
 
         virtual_machines.append(create_response)
 

--- a/tests/compute-engine/server-test.yml
+++ b/tests/compute-engine/server-test.yml
@@ -49,9 +49,42 @@
         state: present
       register: server_create_result
 
+    - name: Provision same two servers again (idempotency)
+      server:
+        datacenter: "{{ datacenter }}"
+        name: "{{ name }} %02d"
+        cores: 1
+        ram: 1024
+        availability_zone: ZONE_1
+        lan: "{{ lan }}"
+        volume_availability_zone: ZONE_3
+        volume_size: 20
+        cpu_family: INTEL_SKYLAKE
+        disk_type: SSD Standard
+        image: "{{ image_alias }}"
+        image_password: "{{ password }}"
+        location: "{{ location }}"
+        user_data: "{{ cloud_init_config.stdout }}"
+        count: 2
+        remove_boot_volume: true
+        wait: true
+        wait_timeout: "{{ wait_timeout }}"
+        state: present
+      register: server_create_result_idempotency
+
     - name: Debug - show result of server create
       debug:
         msg: "{{ server_create_result }}"
+
+    - name: Debug - show result of server create (idempotency)
+      debug:
+        msg: "{{ server_create_result_idempotency }}"
+
+    - name: Asserting that changed == false for creation of identical servers
+      assert:
+        that:
+          - server_create_result_idempotency.changed == false
+        msg: "Changed should be false for idempotency create"
 
     - name: Update servers
       server:

--- a/tests/compute-engine/volume-test.yml
+++ b/tests/compute-engine/volume-test.yml
@@ -33,6 +33,42 @@
         wait_timeout: 600
         wait: true
         state: present
+      register: volume_create_response
+
+    - name: Create same volumes (Idempotency)
+      volume:
+        datacenter: "{{ datacenter }}"
+        name: "{{ name }} %02d"
+        disk_type: SSD Premium
+        image: "{{ image_alias }}"
+        image_password: "{{ password }}"
+        count: 2
+        size: 20
+        availability_zone: ZONE_3
+        cpu_hot_plug: false
+        ram_hot_plug: true
+        nic_hot_plug: true
+        nic_hot_unplug: true
+        disc_virtio_hot_plug: true
+        disc_virtio_hot_unplug: true
+        wait_timeout: 600
+        wait: true
+        state: present
+      register: volume_create_response_idempotency
+
+    - name: Show response of volumes create (idempotency)
+      debug:
+        var: volume_create_response
+
+    - name: Show response of volumes create (idempotency)
+      debug:
+        var: volume_create_response_idempotency
+
+    - name: Asserting that changed == false for creation of identical volumes
+      assert:
+        that:
+          - volume_create_response_idempotency.changed == false
+        msg: "Changed should be false for idempotency create"
 
     - name: Update volume
       volume:


### PR DESCRIPTION
if volume/sevrers with given name already exist, skip creating them - add them to return values. Do not error out anymore (in the future check these resources' properties and if they are different then error out)