### PR TITLE
fix: returned group should be dict

### DIFF
--- a/plugins/modules/group.py
+++ b/plugins/modules/group.py
@@ -303,7 +303,7 @@ def create_group(module, client):
             'changed': False,
             'failed': False,
             'action': 'create',
-            'group': existing_group
+            'group': existing_group.to_dict()
         }
 
     if module.check_mode:


### PR DESCRIPTION
fix `"failed to set Group state present: Value of unknown type: <class 'ionoscloud.models.group.Group'>,`