### PR TITLE
SDK-1308 - Fixes problem where the cube_server module specifies the cpu_family parameter

### DIFF
--- a/docs/api/compute-engine/cube_server.md
+++ b/docs/api/compute-engine/cube_server.md
@@ -11,7 +11,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
         datacenter: Tardis One
         name: web%02d.stackpointcloud.com
         template_id: <template_id>
-        cpu_family: INTEL_XEON
         image: ubuntu:latest
         location: us/las
         count: 3
@@ -23,7 +22,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
         instance_ids:
         - web001.stackpointcloud.com
         - web002.stackpointcloud.com
-        cpu_family: INTEL_XEON
         availability_zone: ZONE_1
         state: update
   # Rename CUBE Virtual machine
@@ -31,7 +29,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
         datacenter: Tardis One
         instance_ids: web001.stackpointcloud.com
         name: web101.stackpointcloud.com
-        cpu_family: INTEL_XEON
         availability_zone: ZONE_1
         state: update
 
@@ -171,7 +168,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
         datacenter: Tardis One
         name: web%02d.stackpointcloud.com
         template_id: <template_id>
-        cpu_family: INTEL_XEON
         image: ubuntu:latest
         location: us/las
         count: 3
@@ -190,7 +186,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
   | ssh_keys | False | list |  | Public SSH keys allowing access to the virtual machine. |
   | user_data | False | str |  | The cloud-init configuration for the volume as base64 encoded string. |
   | datacenter | True | str |  | The datacenter to provision this virtual machine. |
-  | cpu_family | False | str | AMD_OPTERON | The amount of memory to allocate to the virtual machine. |
   | availability_zone | False | str | AUTO | The availability zone assigned to the server. |
   | bus | False | str | VIRTIO | The bus type for the volume. |
   | count | False | int | 1 | The number of virtual machines to create. |
@@ -222,7 +217,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
         instance_ids:
         - web001.stackpointcloud.com
         - web002.stackpointcloud.com
-        cpu_family: INTEL_XEON
         availability_zone: ZONE_1
         state: update
   # Rename CUBE Virtual machine
@@ -230,7 +224,6 @@ Create, update, destroy, update, start, stop, and reboot a Ionos CUBE virtual ma
         datacenter: Tardis One
         instance_ids: web001.stackpointcloud.com
         name: web101.stackpointcloud.com
-        cpu_family: INTEL_XEON
         availability_zone: ZONE_1
         state: update
 

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -35,6 +35,7 @@
     * [Nic Flowlog](api/compute-engine/nic_flowlog.md)
     * [Private cross connect](api/compute-engine/pcc.md)
     * [Server](api/compute-engine/server.md)
+    * [Cube Server](api/compute-engine/cube_server.md)
     * [Snapshot](api/compute-engine/snapshot.md)
     * [Volume](api/compute-engine/volume.md)
 * Container Registry

--- a/plugins/modules/cube_server.py
+++ b/plugins/modules/cube_server.py
@@ -93,14 +93,6 @@ OPTIONS = {
         'required': STATES,
         'type': 'str',
     },
-    'cpu_family': {
-        'description': ['The amount of memory to allocate to the virtual machine.'],
-        'available': ['present'],
-        'choices': ['AMD_OPTERON', 'INTEL_XEON', 'INTEL_SKYLAKE'],
-        'default': 'AMD_OPTERON',
-        'type': 'str',
-        'version_added': '2.2',
-    },
     'availability_zone': {
         'description': ['The availability zone assigned to the server.'],
         'available': ['present'],
@@ -266,7 +258,6 @@ EXAMPLE_PER_STATE = {
         datacenter: Tardis One
         name: web%02d.stackpointcloud.com
         template_id: <template_id>
-        cpu_family: INTEL_XEON
         image: ubuntu:latest
         location: us/las
         count: 3
@@ -278,7 +269,6 @@ EXAMPLE_PER_STATE = {
         instance_ids:
         - web001.stackpointcloud.com
         - web002.stackpointcloud.com
-        cpu_family: INTEL_XEON
         availability_zone: ZONE_1
         state: update
   # Rename CUBE Virtual machine
@@ -286,7 +276,6 @@ EXAMPLE_PER_STATE = {
         datacenter: Tardis One
         instance_ids: web001.stackpointcloud.com
         name: web101.stackpointcloud.com
-        cpu_family: INTEL_XEON
         availability_zone: ZONE_1
         state: update
 ''',
@@ -395,7 +384,6 @@ def _get_lan_by_id_or_properties(networks, id=None, **kwargs):
 
 
 def _create_machine(module, client, datacenter, name):
-    cpu_family = module.params.get('cpu_family')
     disk_type = module.params.get('disk_type')
     availability_zone = module.params.get('availability_zone')
     image_password = module.params.get('image_password')
@@ -455,7 +443,7 @@ def _create_machine(module, client, datacenter, name):
     server_properties = ServerProperties(template_uuid=template_uuid, name=name,
                                           availability_zone=availability_zone,
                                           boot_cdrom=boot_cdrom, boot_volume=boot_volume,
-                                          cpu_family=cpu_family, type='CUBE')
+                                          type='CUBE')
 
     volume_properties = VolumeProperties(name=str(uuid4()).replace('-', '')[:10],
                                           type=disk_type, image_password=image_password,
@@ -665,7 +653,6 @@ def update_server(module, client):
     if not datacenter_id:
         module.fail_json(msg='Virtual data center \'%s\' not found.' % str(datacenter))
 
-    cpu_family = module.params.get('cpu_family')
     availability_zone = module.params.get('availability_zone')
 
     server_list = server_server.datacenters_servers_get(datacenter_id=datacenter_id, depth=1)

--- a/tests/compute-engine/all-tests.yml
+++ b/tests/compute-engine/all-tests.yml
@@ -8,9 +8,8 @@
 - name: Run Attach Volume Test
   import_playbook: attach-volume-test.yml
 
-# Skipped due to Not Enough Physical Resources Error
-#- name: Run Cube Server Test
-#  import_playbook: cube-server-test.yml
+- name: Run Cube Server Test
+  import_playbook: cube-server-test.yml
 
 - name: Run Firewall Test
   import_playbook: firewall-test.yml

--- a/tests/compute-engine/cube-server-test.yml
+++ b/tests/compute-engine/cube-server-test.yml
@@ -19,7 +19,6 @@
       cube_server:
          datacenter: "{{ datacenter }}"
          name: "{{ name }} 01"
-         cpu_family: INTEL_SKYLAKE
          disk_type: DAS
          image: "{{ image_alias }}"
          image_password: "{{ password }}"


### PR DESCRIPTION
## What does this fix or implement?
These changes remove the cpu_family parameter that is no longer supported by the VDC, and whose inclusion throws a "[VDC-5-1921] The attribute 'cpuFamily' must not be provided for Cube servers" error

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [x] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any

