### PR TITLE
feat: Extend Ansible's dynamic inventory to support regex-based grouping

### DIFF
--- a/plugins/inventory/inventory.ini
+++ b/plugins/inventory/inventory.ini
@@ -57,3 +57,32 @@ group_by_availability_zone = False
 # Use the server name instead of the IP as inventory hostname. The IP is still
 # set as ansible_host to connect to the server.
 server_name_as_inventory_hostname = False
+
+[regexgroups]
+# keys: group, value: regex
+# When a regex matches a servername (server.properties.name), then it will be added
+# to the group. 
+# Uses python regex, for example to ignorecase use "(?i)somestring". Reads as
+# RAW string so don't use quotes around string! 
+
+# Example: 
+# given a serverlist: master0, master1, master2, worker, bootstrap, etc.
+# The following config:
+
+# master = ^master
+# worker = ^worker
+# bootstrap = bootstrap
+
+# Will create the following inventory graph:
+# @all:
+#   |--@ungrouped:
+#   |  |--10.x.y.1
+#   |  |--10.x.y.2
+#   |--@worker:
+#   |  |--10.x.y.3
+#   |--@master:
+#   |  |--10.x.y.4    # <- this is master0
+#   |  |--10.x.y.5    # <- this is master1 etc.
+#   |  |--10.x.y.6
+#   |--@bootstrap:
+#   |  |--10.x.y.7


### PR DESCRIPTION
Hello Team, great project and great platform, I enjoy working with this repo a lot!  😄 

## Why this fix?
When trying to create a dynamic inventory I wanted to create more meaningful groups. I didn't find a way to label the servers. So I decided to add the feature to generate inventory groups based on the servername matching a regex.

This feature fixes an issue we were having.

## What does this fix or implement?

The PR extends the dynamic inventory, allowing to create groups based on servernames matching a regex pattern. In this way people can use their servernames in the IONOS cloud as the "label" for their servers. For example if servers are called "webserver1","webserver-west-coast"... "webserver-99", then a regex like `^webserver` can be used to group together in an inventory group of ones choosing like "webservers". Tested extensively.

# Example 
(from updated `inventory.ini`) In the inventory.ini for the dynamic inventory:
```ini
[regexgroups]
# keys: group, value: regex
# When a regex matches a servername (server.properties.name), then it will be added
# to the group. 
# Uses python regex, for example to ignorecase use "(?i)somestring". Reads as
# RAW string so don't use quotes around string! 

# Example: 
# given a serverlist: master0, master1, master2, worker, bootstrap, etc.
# The following config:

master = ^master
worker = ^worker
bootstrap = bootstrap

# Will create the following inventory graph:
# @all:
#   |--@ungrouped:
#   |  |--10.x.y.1
#   |  |--10.x.y.2
#   |--@worker:
#   |  |--10.x.y.3
#   |--@master:
#   |  |--10.x.y.4    # <- this is master0
#   |  |--10.x.y.5    # <- this is master1 etc.
#   |  |--10.x.y.6
#   |--@bootstrap:
#   |  |--10.x.y.7

```

## Checklist

- [X] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [X] Tests added or updated
- [X] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [X] Github Issue linked if any

I leave it to you to increment the version. Suggesting changelog entry: "Extend Ansible's dynamic inventory to support regex-based grouping". This solves an issue we were having internally.

Cheers 
