### PR TITLE
fix: prevent AttributeError from unsafe chained .get() calls in regis…

### DIFF
--- a/plugins/modules/registry.py
+++ b/plugins/modules/registry.py
@@ -287,7 +287,8 @@ class RegistryModule(CommonIonosModule):
                 or gc_schedule.get('time') is not None
                 and existing_object.properties.garbage_collection_schedule.time != gc_schedule.get('time')
             )
-            or features.get('enabled') is not None
+            or features is not None
+            and features.get('vulnerability_scanning', {}).get('enabled') is not None
             and existing_object.properties.features.vulnerability_scanning.enabled == False
             and features.get('vulnerability_scanning', {}).get('enabled') == True
         )
@@ -319,7 +320,7 @@ class RegistryModule(CommonIonosModule):
             )
         if features:
             vulnerability_scanning_feature = ionoscloud_container_registry.FeatureVulnerabilityScanning(
-                enabled=features.get('vulnerability_scanning').get('enabled'),
+                enabled=features.get('vulnerability_scanning', {}).get('enabled'),
             )
         name = self.module.params.get('name')
         location = self.module.params.get('location')
@@ -371,7 +372,7 @@ class RegistryModule(CommonIonosModule):
             )
         if features:
             vulnerability_scanning_feature = ionoscloud_container_registry.FeatureVulnerabilityScanning(
-                enabled=features.get('vulnerability_scanning').get('enabled'),
+                enabled=features.get('vulnerability_scanning', {}).get('enabled'),
             )
 
         registries_api = ionoscloud_container_registry.RegistriesApi(client)


### PR DESCRIPTION
…try module

The `features` dict lookups used chained `.get()` calls without null safety, e.g. `features.get('vulnerability_scanning').get('enabled')`. If `vulnerability_scanning` key is absent, the first `.get()` returns None, causing an AttributeError on the second `.get()`.

Additionally, `_should_update_object` accessed `features.get('enabled')` without checking if `features` is None and used the wrong key path.

## What does this fix or implement?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Checklist

<!-- Please check the completed items below -->

<!-- Not all changes require documentation updates or tests to be added or updated -->

- [ ] PR name added as appropriate (e.g. feat/fix/doc/test/refactor/etc)
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Changelog updated and version incremented (label: upcoming release)
- [ ] Github Issue linked if any

