### PR TITLE
feat: add volume performance classes to disk_type options

### DIFF
--- a/docs/api/compute-engine/cube_server.md
+++ b/docs/api/compute-engine/cube_server.md
@@ -591,7 +591,7 @@ register: server_cube
   <tr>
   <td>disk_type<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The disk type for the volume.<br />Default: DAS<br />Options: ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS']</td>
+  <td>The disk type for the volume.<br />Default: DAS<br />Options: ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE']</td>
   </tr>
   <tr>
   <td>nic_ips<br/><mark style="color:blue;">list</mark></td>

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -546,7 +546,7 @@ register: server_create_result
   <tr>
   <td>disk_type<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The disk type for the volume.<br />Default: HDD<br />Options: ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS']</td>
+  <td>The disk type for the volume.<br />Default: HDD<br />Options: ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE']</td>
   </tr>
   <tr>
   <td>nic_ips<br/><mark style="color:blue;">list</mark></td>

--- a/docs/api/compute-engine/vcpu_server.md
+++ b/docs/api/compute-engine/vcpu_server.md
@@ -465,7 +465,7 @@ register: server_create_result
   <tr>
   <td>disk_type<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The disk type for the volume.<br />Default: HDD<br />Options: ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS']</td>
+  <td>The disk type for the volume.<br />Default: HDD<br />Options: ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE']</td>
   </tr>
   <tr>
   <td>nic_ips<br/><mark style="color:blue;">list</mark></td>

--- a/docs/api/compute-engine/volume.md
+++ b/docs/api/compute-engine/volume.md
@@ -214,7 +214,7 @@ register: volume_create_response
   <tr>
   <td>disk_type<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The disk type of the volume.<br />Options: ['HDD', 'SSD', 'SSD Premium', 'SSD Standard', 'DAS', 'ISO']</td>
+  <td>The disk type of the volume.<br />Options: ['HDD', 'SSD', 'SSD Premium', 'SSD Standard', 'DAS', 'ISO', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE']</td>
   </tr>
   <tr>
   <td>licence_type<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/compute-engine/volume.md
+++ b/docs/api/compute-engine/volume.md
@@ -213,7 +213,7 @@ register: volume_create_response
   <tr>
   <td>disk_type<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The disk type of the volume.<br />Options: ['HDD', 'SSD', 'SSD Premium', 'SSD Standard', 'DAS', 'ISO']</td>
+  <td>The disk type of the volume.<br />Options: ['HDD', 'SSD', 'SSD Premium', 'SSD Standard', 'DAS', 'ISO', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE']</td>
   </tr>
   <tr>
   <td>licence_type<br/><mark style="color:blue;">str</mark></td>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.7.2
+### Features
+* added volume performance classes `ESSENTIAL`, `BALANCED` and `PERFORMANCE` to the `disk_type` options of the `volume`, `server`, `cube_server` and `vcpu_server` modules
+
 ## 7.7.1
 ### Fixes
 * added pagination to DNS modules (`dns_zone`, `dns_zone_info`, `dns_record`, `dns_record_info`, `dns_secondary_zone`, `dns_secondary_zone_info`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 7.8.0
 ### Features
 * added new DBaaS PostgreSQL v2 modules `postgres_cluster_v2`, `postgres_cluster_v2_info`, `postgres_backup_v2_info`, `postgres_backup_location_v2_info` and `postgres_version_v2_info`
+* added volume performance classes `ESSENTIAL`, `BALANCED` and `PERFORMANCE` to the `disk_type` options of the `volume`, `server`, `cube_server` and `vcpu_server` modules
 ### Changes
 * updated SDK requirements to the latest major releases (built on pydantic 2): `ionoscloud_dbaas_postgres>=3`, `ionoscloud_cert_manager>=3`, `ionoscloud_container_registry>=2`, `ionoscloud_dbaas_mariadb>=2`, `ionoscloud_dns>=2`, `ionoscloud_logging>=2`, `ionoscloud_object_storage_management>=2` and `ionoscloud_vm_autoscaling>=2`; older SDK versions are no longer supported
 ### Fixes

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ namespace: ionoscloudsdk
 name: ionoscloud
 
 # The version of the collection.
-version: 7.7.1
+version: 7.7.2
 
 readme: README.md
 

--- a/plugins/modules/cube_server.py
+++ b/plugins/modules/cube_server.py
@@ -148,7 +148,7 @@ OPTIONS = {
     'disk_type': {
         'description': ['The disk type for the volume.'],
         'available': ['present'],
-        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS'],
+        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE'],
         'default': 'DAS',
         'type': 'str',
     },
@@ -252,6 +252,9 @@ options:
         - SSD Standard
         - SSD Premium
         - DAS
+        - ESSENTIAL
+        - BALANCED
+        - PERFORMANCE
         default: DAS
         description:
         - The disk type for the volume.

--- a/plugins/modules/cube_server.py
+++ b/plugins/modules/cube_server.py
@@ -148,7 +148,7 @@ OPTIONS = {
     'disk_type': {
         'description': ['The disk type for the volume.'],
         'available': ['present'],
-        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS'],
+        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE'],
         'default': 'DAS',
         'type': 'str',
     },
@@ -264,6 +264,9 @@ options:
         - SSD Standard
         - SSD Premium
         - DAS
+        - ESSENTIAL
+        - BALANCED
+        - PERFORMANCE
         default: DAS
         description:
         - The disk type for the volume.

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -186,7 +186,7 @@ OPTIONS = {
     'disk_type': {
         'description': ['The disk type for the volume.'],
         'available': ['present'],
-        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS'],
+        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE'],
         'default': 'HDD',
         'type': 'str',
     },
@@ -303,6 +303,9 @@ options:
         - SSD Standard
         - SSD Premium
         - DAS
+        - ESSENTIAL
+        - BALANCED
+        - PERFORMANCE
         default: HDD
         description:
         - The disk type for the volume.

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -186,7 +186,7 @@ OPTIONS = {
     'disk_type': {
         'description': ['The disk type for the volume.'],
         'available': ['present'],
-        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS'],
+        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE'],
         'default': 'HDD',
         'type': 'str',
     },
@@ -324,6 +324,9 @@ options:
         - SSD Standard
         - SSD Premium
         - DAS
+        - ESSENTIAL
+        - BALANCED
+        - PERFORMANCE
         default: HDD
         description:
         - The disk type for the volume.

--- a/plugins/modules/vcpu_server.py
+++ b/plugins/modules/vcpu_server.py
@@ -179,7 +179,7 @@ OPTIONS = {
     'disk_type': {
         'description': ['The disk type for the volume.'],
         'available': ['present'],
-        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS'],
+        'choices_docs': ['HDD', 'SSD', 'SSD Standard', 'SSD Premium', 'DAS', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE'],
         'default': 'HDD',
         'type': 'str',
     },
@@ -277,6 +277,9 @@ options:
         - SSD Standard
         - SSD Premium
         - DAS
+        - ESSENTIAL
+        - BALANCED
+        - PERFORMANCE
         default: HDD
         description:
         - The disk type for the volume.

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -91,7 +91,7 @@ OPTIONS = {
     },
     'disk_type': {
         'description': ['The disk type of the volume.'],
-        'choices_docs': ['HDD', 'SSD', 'SSD Premium', 'SSD Standard', 'DAS', 'ISO'],
+        'choices_docs': ['HDD', 'SSD', 'SSD Premium', 'SSD Standard', 'DAS', 'ISO', 'ESSENTIAL', 'BALANCED', 'PERFORMANCE'],
         'available': ['present'],
         'type': 'str',
     },
@@ -276,6 +276,9 @@ options:
         - SSD Standard
         - DAS
         - ISO
+        - ESSENTIAL
+        - BALANCED
+        - PERFORMANCE
         description:
         - The disk type of the volume.
         required: false


### PR DESCRIPTION
Adds the new volume performance classes `ESSENTIAL`, `BALANCED` and `PERFORMANCE` to the `disk_type` options of the `volume`, `server`, `cube_server` and `vcpu_server` modules. Regenerated docs and bumped the changelog to 7.7.2.

No behaviour change: `disk_type` is passed straight to the API and choices are documentation-only. Draft until the classes are live on the API.