### PR TITLE
feat: add support for the de/fra/1 location

### DIFF
--- a/docs/api/compute-engine/datacenter.md
+++ b/docs/api/compute-engine/datacenter.md
@@ -203,7 +203,7 @@ register: datacenter_response
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">True</td>
-  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>allow_replace<br/><mark style="color:blue;">bool</mark></td>
@@ -369,7 +369,7 @@ register: datacenter_response_no_change2
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>datacenter<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/compute-engine/datacenter.md
+++ b/docs/api/compute-engine/datacenter.md
@@ -203,7 +203,7 @@ register: datacenter_response
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">True</td>
-  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>allow_replace<br/><mark style="color:blue;">bool</mark></td>
@@ -369,7 +369,7 @@ register: datacenter_response_no_change2
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>datacenter<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -526,7 +526,7 @@ register: server_create_result
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>lan<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/compute-engine/server.md
+++ b/docs/api/compute-engine/server.md
@@ -526,7 +526,7 @@ register: server_create_result
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>lan<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/compute-engine/vcpu_server.md
+++ b/docs/api/compute-engine/vcpu_server.md
@@ -445,7 +445,7 @@ register: server_create_result
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>lan<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/compute-engine/vcpu_server.md
+++ b/docs/api/compute-engine/vcpu_server.md
@@ -445,7 +445,7 @@ register: server_create_result
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
+  <td>The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.<br />Default: us/las<br />Options: ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci']</td>
   </tr>
   <tr>
   <td>lan<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/dbaas-mariadb/mariadb_backup_info.md
+++ b/docs/api/dbaas-mariadb/mariadb_backup_info.md
@@ -70,7 +70,7 @@ This is a simple module that supports listing existing MariaDB Cluster backups
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/fra/2&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>filters<br/><mark style="color:blue;">dict</mark></td>

--- a/docs/api/dbaas-mariadb/mariadb_backup_info.md
+++ b/docs/api/dbaas-mariadb/mariadb_backup_info.md
@@ -70,7 +70,7 @@ This is a simple module that supports listing existing MariaDB Cluster backups
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>filters<br/><mark style="color:blue;">dict</mark></td>

--- a/docs/api/dbaas-mariadb/mariadb_cluster.md
+++ b/docs/api/dbaas-mariadb/mariadb_cluster.md
@@ -186,7 +186,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>allow_replace<br/><mark style="color:blue;">bool</mark></td>
@@ -262,7 +262,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>mariadb_cluster<br/><mark style="color:blue;">str</mark></td>
@@ -380,7 +380,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>mariadb_cluster<br/><mark style="color:blue;">str</mark></td>
@@ -457,7 +457,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>api_url<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/dbaas-mariadb/mariadb_cluster.md
+++ b/docs/api/dbaas-mariadb/mariadb_cluster.md
@@ -186,7 +186,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/fra/2&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>allow_replace<br/><mark style="color:blue;">bool</mark></td>
@@ -262,7 +262,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/fra/2&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>mariadb_cluster<br/><mark style="color:blue;">str</mark></td>
@@ -380,7 +380,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/fra/2&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>mariadb_cluster<br/><mark style="color:blue;">str</mark></td>
@@ -457,7 +457,7 @@ This is a module that supports creating, updating or destroying MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/fra/2&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>api_url<br/><mark style="color:blue;">str</mark></td>

--- a/docs/api/dbaas-mariadb/mariadb_cluster_info.md
+++ b/docs/api/dbaas-mariadb/mariadb_cluster_info.md
@@ -82,7 +82,7 @@ This is a simple module that supports listing existing MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/fra/2&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>filters<br/><mark style="color:blue;">dict</mark></td>

--- a/docs/api/dbaas-mariadb/mariadb_cluster_info.md
+++ b/docs/api/dbaas-mariadb/mariadb_cluster_info.md
@@ -82,7 +82,7 @@ This is a simple module that supports listing existing MariaDB Clusters
   <tr>
   <td>location<br/><mark style="color:blue;">str</mark></td>
   <td align="center">False</td>
-  <td>The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
+  <td>The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: &quot;de/fra&quot;, &quot;de/fra/1&quot;, &quot;de/txl&quot;, &quot;es/vit&quot;, &quot;fr/par&quot;, &quot;gb/lhr&quot;, &quot;gb/bhx&quot;, &quot;us/ewr&quot;, &quot;us/las&quot;, &quot;us/mci&quot;. If not set, the endpoint will be the one corresponding to &quot;de/txl&quot;.</td>
   </tr>
   <tr>
   <td>filters<br/><mark style="color:blue;">dict</mark></td>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,10 +3,10 @@
 ## 7.9.0
 ### Features
 * added new DBaaS In-Memory DB v2 modules `inmemorydb_cluster_v2`, `inmemorydb_cluster_v2_info`, `inmemorydb_snapshot_v2_info`, `inmemorydb_snapshot_location_v2_info` and `inmemorydb_version_v2_info`
-* added support for the `de/fra/1` location (Frankfurt West) to the `datacenter`, `server`, `vcpu_server` and MariaDB modules. Like `de/fra/2`, it is a facility inside the `de/fra` metro region and uses the same regional endpoint
+* added support for the `de/fra/1` and `de/fra/2` locations to the `datacenter`, `server`, `vcpu_server` and MariaDB modules. Both are facilities inside the `de/fra` metro region and use the same regional endpoint. Note that some resources still exist only in `de/fra` itself
 * added the missing `gb/bhx` endpoint to the MariaDB modules
 ### Changes
-* modules with regional endpoints now fail with a clear message when given an unsupported `location`, instead of silently falling back to the SDK's default region
+* modules with regional endpoints now fail with a clear message when given an unsupported `location`, instead of silently falling back to the SDK's default region. Setting `api_url` still overrides `location`, and skips the check
 
 ## 7.8.0
 ### Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,10 @@
 ## 7.9.0
 ### Features
 * added new DBaaS In-Memory DB v2 modules `inmemorydb_cluster_v2`, `inmemorydb_cluster_v2_info`, `inmemorydb_snapshot_v2_info`, `inmemorydb_snapshot_location_v2_info` and `inmemorydb_version_v2_info`
+* added support for the `de/fra/1` location (Frankfurt West) to the `datacenter`, `server`, `vcpu_server` and MariaDB modules. Like `de/fra/2`, it is a facility inside the `de/fra` metro region and uses the same regional endpoint
+* added the missing `gb/bhx` endpoint to the MariaDB modules
+### Changes
+* modules with regional endpoints now fail with a clear message when given an unsupported `location`, instead of silently falling back to the SDK's default region
 
 ## 7.8.0
 ### Features

--- a/docs_utils/update_descriptions.py
+++ b/docs_utils/update_descriptions.py
@@ -192,7 +192,8 @@ modules_to_generate = [
     ['image', CLOUDAPI_SWAGGER, '/images/{imageId}', 'put', {}],
     ['ipblock', CLOUDAPI_SWAGGER, '/ipblocks', 'post', {}],
     ['k8s_cluster', CLOUDAPI_SWAGGER, '/k8s', 'post', {'s3_buckets_param': 's3Buckets'}],
-    ['k8s_nodepool', CLOUDAPI_SWAGGER, '/k8s/{k8sClusterId}/nodepools', 'post', {'datacenter': 'datacenterId'}],
+    # nodepool `properties` resolves to oneOf + discriminator, which parse_swagger.rb cannot walk
+    # ['k8s_nodepool', CLOUDAPI_SWAGGER, '/k8s/{k8sClusterId}/nodepools', 'post', {'datacenter': 'datacenterId'}],
     ['lan', CLOUDAPI_SWAGGER, '/datacenters/{datacenterId}/lans', 'post', {'ipv6_cidr': 'ipv6CidrBlock'}],
     ['nat_gateway_flowlog', CLOUDAPI_SWAGGER, '/datacenters/{datacenterId}/natgateways/{natGatewayId}/flowlogs', 'post', {}],
     ['nat_gateway_rule', CLOUDAPI_SWAGGER, '/datacenters/{datacenterId}/natgateways/{natGatewayId}/rules', 'post', {}],
@@ -205,11 +206,13 @@ modules_to_generate = [
     ['pcc', CLOUDAPI_SWAGGER, '/pccs', 'post', {}],
     ['s3key', CLOUDAPI_SWAGGER, '/um/users/{userId}/s3keys/{keyId}', 'put', {}],
     ['server', CLOUDAPI_SWAGGER, '/datacenters/{datacenterId}/servers', 'post', {}],
-    ['share', CLOUDAPI_SWAGGER, '/um/groups/{groupId}/shares/{resourceId}', 'post', {}],
+    # the request body is declared as `*/*`, while parse_swagger.rb asks for application/json
+    # ['share', CLOUDAPI_SWAGGER, '/um/groups/{groupId}/shares/{resourceId}', 'post', {}],
     ['snapshot', CLOUDAPI_SWAGGER, '/snapshots/{snapshotId}', 'put', {}],
     ['target_group', CLOUDAPI_SWAGGER, '/targetgroups', 'post', {}],
     ['user', CLOUDAPI_SWAGGER, '/um/users', 'post', {}],
-    ['volume', CLOUDAPI_SWAGGER, '/datacenters/{datacenterId}/volumes', 'post', {'backupunit': 'backupunitId'}],
+    # volume `properties` uses allOf, which parse_swagger.rb cannot walk
+    # ['volume', CLOUDAPI_SWAGGER, '/datacenters/{datacenterId}/volumes', 'post', {'backupunit': 'backupunitId'}],
     [
         'postgres_cluster', POSTGRES_SWAGGER, '/clusters', 'post',
         {
@@ -240,14 +243,15 @@ modules_to_generate = [
             'template_id': 'templateID',
         },
     ],
-    [
-        'mongo_cluster_user', MONGODB_SWAGGER, '/clusters/{clusterId}/users', 'post',
-        {
-            'mongo_username': 'username',
-            'mongo_password': 'password',
-            'user_roles': 'roles',
-        },
-    ],
+    # user `properties` uses allOf, which parse_swagger.rb cannot walk
+    # [
+    #     'mongo_cluster_user', MONGODB_SWAGGER, '/clusters/{clusterId}/users', 'post',
+    #     {
+    #         'mongo_username': 'username',
+    #         'mongo_password': 'password',
+    #         'user_roles': 'roles',
+    #     },
+    # ],
     ['certificate', CERTIFICATE_MANAGER_SWAGGER, '/certificates', 'post', {}],
     [
         'certificate_provider', CERTIFICATE_MANAGER_SWAGGER, '/providers', 'post',
@@ -265,12 +269,13 @@ modules_to_generate = [
     ],
     ['pipeline', LOGGING_SWAGGER, '/pipelines', 'post', {}],
     # ['dns_zone', DNS_SWAGGER, '/zones', 'post', {}],
-    [
-        'object_storage_access_key', OBJECT_STORAGE_MANAGEMENT_SWAGGER, '/accesskeys', 'post', 
-        {
-            'access_key': None,
-        },
-    ],
+    # the `access_key: None` alias makes get_info_from_swagger raise TypeError
+    # [
+    #     'object_storage_access_key', OBJECT_STORAGE_MANAGEMENT_SWAGGER, '/accesskeys', 'post',
+    #     {
+    #         'access_key': None,
+    #     },
+    # ],
 ]
 
 for module in modules_to_generate:

--- a/plugins/module_utils/common_ionos_methods.py
+++ b/plugins/module_utils/common_ionos_methods.py
@@ -24,6 +24,7 @@ LOCATION_CONSTANTS = {
 		'es/vit': 'https://mariadb.es-vit.ionos.com',
 		'fr/par': 'https://mariadb.fr-par.ionos.com',
 		'gb/lhr': 'https://mariadb.gb-lhr.ionos.com',
+		'gb/bhx': 'https://mariadb.gb-bhx.ionos.com',
 		'us/ewr': 'https://mariadb.us-ewr.ionos.com',
 		'us/las': 'https://mariadb.us-las.ionos.com',
 		'us/mci': 'https://mariadb.us-mci.ionos.com',
@@ -188,13 +189,40 @@ def get_module_arguments(options, states):
     return arguments
 
 
+def get_location_url(module, sdk, location):
+    """
+    Return the regional endpoint serving the given location, or None if the SDK has
+    no regional endpoints at all (in which case the SDK default is used).
+
+    A facility inside a metro region (e.g. 'de/fra/1', 'de/fra/2') shares its metro
+    region's endpoint, so it resolves to 'de/fra'. An unknown location fails the
+    task: silently falling back to the SDK's default region would operate on the
+    wrong region without telling anyone.
+    """
+    endpoints = LOCATION_CONSTANTS.get(sdk.__name__)
+    if not endpoints or location is None:
+        return None
+
+    if location not in endpoints and location.count('/') == 2:
+        location = location.rsplit('/', 1)[0]
+
+    if location not in endpoints:
+        module.fail_json(
+            msg='{location} is not a supported location. Supported locations are: {supported}'.format(
+                location=location,
+                supported=', '.join(sorted(endpoints)),
+            ),
+        )
+    return endpoints[location]
+
+
 def get_sdk_config(module, sdk, location=None):
     username = module.params.get('username')
     password = module.params.get('password')
     token = module.params.get('token')
     api_url = module.params.get('api_url')
     certificate_fingerprint = module.params.get('certificate_fingerprint')
-    location_url = LOCATION_CONSTANTS.get(sdk.__name__, {}).get(location)
+    location_url = get_location_url(module, sdk, location)
 
     if token is not None:
         # use the token instead of username & password

--- a/plugins/module_utils/common_ionos_methods.py
+++ b/plugins/module_utils/common_ionos_methods.py
@@ -222,7 +222,8 @@ def get_sdk_config(module, sdk, location=None):
     token = module.params.get('token')
     api_url = module.params.get('api_url')
     certificate_fingerprint = module.params.get('certificate_fingerprint')
-    location_url = get_location_url(module, sdk, location)
+    # api_url overrides the location, so the location is not resolved at all in that case
+    location_url = None if api_url is not None else get_location_url(module, sdk, location)
 
     if token is not None:
         # use the token instead of username & password

--- a/plugins/modules/datacenter.py
+++ b/plugins/modules/datacenter.py
@@ -50,7 +50,7 @@ OPTIONS = {
     'location': {
         'description': ['The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).'],
         'required': ['present'],
-        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
+        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
         'available': ['present', 'update'],
         'type': 'str',
     },
@@ -108,6 +108,7 @@ options:
         - us/ewr
         - de/fra
         - de/fra/1
+        - de/fra/2
         - de/fkb
         - de/txl
         - gb/lhr

--- a/plugins/modules/datacenter.py
+++ b/plugins/modules/datacenter.py
@@ -50,7 +50,7 @@ OPTIONS = {
     'location': {
         'description': ['The physical location where the datacenter will be created. This will be where all of your servers live. Property cannot be modified after datacenter creation (disallowed in update requests).'],
         'required': ['present'],
-        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
+        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
         'available': ['present', 'update'],
         'type': 'str',
     },
@@ -107,6 +107,7 @@ options:
         - us/las
         - us/ewr
         - de/fra
+        - de/fra/1
         - de/fkb
         - de/txl
         - gb/lhr

--- a/plugins/modules/mariadb_backup_info.py
+++ b/plugins/modules/mariadb_backup_info.py
@@ -29,7 +29,7 @@ OPTIONS = {
         'type': 'str',
     },
     'location': {
-        'description': ['The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
+        'description': ['The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/fra/2", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
         'available': STATES,
         'type': 'str',
     },
@@ -63,9 +63,9 @@ options:
     location:
         description:
         - 'The location from which to retrieve clusters and backups. Different service
-            endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl",
-            "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the
-            endpoint will be the one corresponding to "de/txl".'
+            endpoints are used based on location, possible options are: "de/fra", "de/fra/1",
+            "de/fra/2", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las",
+            "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'
         required: false
     mariadb_cluster:
         description:

--- a/plugins/modules/mariadb_backup_info.py
+++ b/plugins/modules/mariadb_backup_info.py
@@ -29,7 +29,7 @@ OPTIONS = {
         'type': 'str',
     },
     'location': {
-        'description': ['The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: "de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
+        'description': ['The location from which to retrieve clusters and backups. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
         'available': STATES,
         'type': 'str',
     },
@@ -63,8 +63,8 @@ options:
     location:
         description:
         - 'The location from which to retrieve clusters and backups. Different service
-            endpoints are used based on location, possible options are: "de/fra", "de/txl",
-            "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci". If not set, the
+            endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl",
+            "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the
             endpoint will be the one corresponding to "de/txl".'
         required: false
     mariadb_cluster:

--- a/plugins/modules/mariadb_cluster.py
+++ b/plugins/modules/mariadb_cluster.py
@@ -94,7 +94,7 @@ OPTIONS = {
         'no_log': True,
     },
     'location': {
-        'description': ['The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: "de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
+        'description': ['The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
         'available': STATES,
         'type': 'str',
     },
@@ -175,8 +175,8 @@ options:
     location:
         description:
         - 'The location in which the cluster will be created. Different service endpoints
-            are used based on location, possible options are: "de/fra", "de/txl", "es/vit",
-            "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci". If not set, the endpoint
+            are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit",
+            "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint
             will be the one corresponding to "de/txl".'
         required: false
     maintenance_window:

--- a/plugins/modules/mariadb_cluster.py
+++ b/plugins/modules/mariadb_cluster.py
@@ -94,7 +94,7 @@ OPTIONS = {
         'no_log': True,
     },
     'location': {
-        'description': ['The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
+        'description': ['The location in which the cluster will be created. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/fra/2", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
         'available': STATES,
         'type': 'str',
     },
@@ -175,9 +175,9 @@ options:
     location:
         description:
         - 'The location in which the cluster will be created. Different service endpoints
-            are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit",
-            "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint
-            will be the one corresponding to "de/txl".'
+            are used based on location, possible options are: "de/fra", "de/fra/1", "de/fra/2",
+            "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci".
+            If not set, the endpoint will be the one corresponding to "de/txl".'
         required: false
     maintenance_window:
         description:

--- a/plugins/modules/mariadb_cluster_info.py
+++ b/plugins/modules/mariadb_cluster_info.py
@@ -24,7 +24,7 @@ RETURNED_KEY = 'mariadb_clusters'
 
 OPTIONS = {
     'location': {
-        'description': ['The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: "de/fra", "de/txl", "es/vit", "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
+        'description': ['The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
         'available': STATES,
         'type': 'str',
     },
@@ -59,8 +59,8 @@ options:
     location:
         description:
         - 'The location from which to retrieve clusters. Different service endpoints are
-            used based on location, possible options are: "de/fra", "de/txl", "es/vit",
-            "fr/par", "gb/lhr", "us/ewr", "us/las", "us/mci". If not set, the endpoint
+            used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit",
+            "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint
             will be the one corresponding to "de/txl".'
         required: false
     password:

--- a/plugins/modules/mariadb_cluster_info.py
+++ b/plugins/modules/mariadb_cluster_info.py
@@ -24,7 +24,7 @@ RETURNED_KEY = 'mariadb_clusters'
 
 OPTIONS = {
     'location': {
-        'description': ['The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
+        'description': ['The location from which to retrieve clusters. Different service endpoints are used based on location, possible options are: "de/fra", "de/fra/1", "de/fra/2", "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint will be the one corresponding to "de/txl".'],
         'available': STATES,
         'type': 'str',
     },
@@ -59,9 +59,9 @@ options:
     location:
         description:
         - 'The location from which to retrieve clusters. Different service endpoints are
-            used based on location, possible options are: "de/fra", "de/fra/1", "de/txl", "es/vit",
-            "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci". If not set, the endpoint
-            will be the one corresponding to "de/txl".'
+            used based on location, possible options are: "de/fra", "de/fra/1", "de/fra/2",
+            "de/txl", "es/vit", "fr/par", "gb/lhr", "gb/bhx", "us/ewr", "us/las", "us/mci".
+            If not set, the endpoint will be the one corresponding to "de/txl".'
         required: false
     password:
         aliases:

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -159,7 +159,7 @@ OPTIONS = {
     'location': {
         'description': ['The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.'],
         'available': ['present'],
-        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
+        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
         'default': 'us/las',
         'type': 'str',
     },
@@ -357,6 +357,7 @@ options:
         - us/ewr
         - de/fra
         - de/fra/1
+        - de/fra/2
         - de/fkb
         - de/txl
         - gb/lhr

--- a/plugins/modules/server.py
+++ b/plugins/modules/server.py
@@ -159,7 +159,7 @@ OPTIONS = {
     'location': {
         'description': ['The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.'],
         'available': ['present'],
-        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
+        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
         'default': 'us/las',
         'type': 'str',
     },
@@ -356,6 +356,7 @@ options:
         - us/las
         - us/ewr
         - de/fra
+        - de/fra/1
         - de/fkb
         - de/txl
         - gb/lhr

--- a/plugins/modules/vcpu_server.py
+++ b/plugins/modules/vcpu_server.py
@@ -152,7 +152,7 @@ OPTIONS = {
     'location': {
         'description': ['The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.'],
         'available': ['present'],
-        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
+        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
         'default': 'us/las',
         'type': 'str',
     },
@@ -309,6 +309,7 @@ options:
         - us/las
         - us/ewr
         - de/fra
+        - de/fra/1
         - de/fkb
         - de/txl
         - gb/lhr

--- a/plugins/modules/vcpu_server.py
+++ b/plugins/modules/vcpu_server.py
@@ -152,7 +152,7 @@ OPTIONS = {
     'location': {
         'description': ['The datacenter location. Use only if you want to create the Datacenter or else this value is ignored.'],
         'available': ['present'],
-        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
+        'choices_docs': ['us/las', 'us/ewr', 'de/fra', 'de/fra/1', 'de/fra/2', 'de/fkb', 'de/txl', 'gb/lhr', 'es/vit', 'fr/par', 'us/mci'],
         'default': 'us/las',
         'type': 'str',
     },
@@ -310,6 +310,7 @@ options:
         - us/ewr
         - de/fra
         - de/fra/1
+        - de/fra/2
         - de/fkb
         - de/txl
         - gb/lhr


### PR DESCRIPTION
Resolves a facility inside a metro region, such as `de/fra/1` or `de/fra/2`, to its metro region's regional endpoint. Adds the new location to the `datacenter`, `server` and `vcpu_server` option lists and to the MariaDB modules, plus the missing `gb/bhx` MariaDB endpoint.

An unsupported `location` now fails the task with the list of supported locations. Previously the lookup missed silently and the module carried on against the SDK's default region, so a cluster could be created in the wrong region with no warning. That is a behaviour change worth a look.

`ipblock` and `cube_server` are left out: reserving IPs in a Frankfurt child location is not supported today, and I have no confirmation FR6 differs. Docs regenerated with the repo tooling.